### PR TITLE
fix: uninitialized member in ObjectNodeAttributes struct

### DIFF
--- a/include/spark_dsg/node_attributes.h
+++ b/include/spark_dsg/node_attributes.h
@@ -88,7 +88,7 @@ struct NodeAttributes {
   //! last time the place was updated (while active)
   uint64_t last_update_time_ns;
   //! whether or not the node is in the active window
-  bool is_active = false;
+  bool is_active;
 
  protected:
   //! actually output information to the std::ostream
@@ -126,7 +126,7 @@ struct SemanticNodeAttributes : public NodeAttributes {
   }
 
   //! Name of the node
-  std::string name = "";
+  std::string name;
   //! Color of the node (if it exists)
   ColorVector color;
   //! Extents of the node (if they exists)

--- a/src/node_attributes.cpp
+++ b/src/node_attributes.cpp
@@ -39,7 +39,7 @@ namespace spark_dsg {
 NodeAttributes::NodeAttributes() : NodeAttributes(Eigen::Vector3d::Zero()) {}
 
 NodeAttributes::NodeAttributes(const Eigen::Vector3d& pos)
-    : position(pos), last_update_time_ns(0) {}
+    : position(pos), last_update_time_ns(0), is_active(false) {}
 
 std::ostream& NodeAttributes::fill_ostream(std::ostream& out) const {
   auto format = getDefaultVectorFormat();

--- a/src/node_attributes.cpp
+++ b/src/node_attributes.cpp
@@ -69,7 +69,9 @@ std::ostream& SemanticNodeAttributes::fill_ostream(std::ostream& out) const {
 }
 
 ObjectNodeAttributes::ObjectNodeAttributes()
-    : SemanticNodeAttributes(), world_R_object(Eigen::Quaterniond::Identity()) {}
+    : SemanticNodeAttributes(),
+      world_R_object(Eigen::Quaterniond::Identity()),
+      registered(false) {}
 
 std::ostream& ObjectNodeAttributes::fill_ostream(std::ostream& out) const {
   // TODO(nathan) think about printing out rotation here


### PR DESCRIPTION
While porting the Hydra project to ubuntu 22.04 I stumbled upon a bug where the `dsg_streaming_interface` in `hydra_ros`  threw errors while deserializing the DSG data. Turns out it was due to the `registered` member of the `ObjectNodeAttributes` struct which was not initialized and therefore contained values > 1.
I also tried to make the initialization location consistent for all NodeAttribute structs.

Thank you for your work, I hope this helps!