### PR TITLE
switch feature vector to single precision

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(spark_dsg VERSION 1.0.4)
+project(spark_dsg VERSION 1.0.5)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/include/spark_dsg/node_attributes.h
+++ b/include/spark_dsg/node_attributes.h
@@ -177,7 +177,7 @@ struct SemanticNodeAttributes : public NodeAttributes {
   //! semantic label of object
   SemanticLabel semantic_label;
   //! semantic feature of object
-  Eigen::MatrixXd semantic_feature;
+  Eigen::MatrixXf semantic_feature;
 
  protected:
   std::ostream& fill_ostream(std::ostream& out) const override;

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>spark_dsg</name>
-  <version>1.0.2</version>
+  <version>1.0.5</version>
   <description>Dynamic Scene Graph (DSG) type definitions and core library code</description>
 
   <author email="na26933@mit.edu">Nathan Hughes</author>

--- a/src/node_attributes.cpp
+++ b/src/node_attributes.cpp
@@ -193,7 +193,13 @@ void SemanticNodeAttributes::serialization_info() {
   }
   serialization::field("bounding_box", bounding_box);
   serialization::field("semantic_label", semantic_label);
-  serialization::field("semantic_feature", semantic_feature);
+  if (header.version < io::Version(1, 0, 4)) {
+    Eigen::MatrixXd feature;
+    serialization::field("semantic_feature", feature);
+    semantic_feature = feature.cast<float>();
+  } else {
+    serialization::field("semantic_feature", semantic_feature);
+  }
 }
 
 bool SemanticNodeAttributes::is_equal(const NodeAttributes& other) const {

--- a/src/node_attributes.cpp
+++ b/src/node_attributes.cpp
@@ -193,7 +193,7 @@ void SemanticNodeAttributes::serialization_info() {
   }
   serialization::field("bounding_box", bounding_box);
   serialization::field("semantic_label", semantic_label);
-  if (header.version < io::Version(1, 0, 4)) {
+  if (header.version <= io::Version(1, 0, 4)) {
     Eigen::MatrixXd feature;
     serialization::field("semantic_feature", feature);
     semantic_feature = feature.cast<float>();

--- a/tests/utest_node_attributes.cpp
+++ b/tests/utest_node_attributes.cpp
@@ -47,13 +47,13 @@ TEST(NodeAttributes, SemanticNodeAttributes) {
   EXPECT_TRUE(attrs.hasLabel());
   EXPECT_FALSE(attrs.hasFeature());
   // empty matrices should not be registered
-  attrs.semantic_feature = Eigen::MatrixXd(0, 1);
+  attrs.semantic_feature = Eigen::MatrixXf(0, 1);
   EXPECT_FALSE(attrs.hasFeature());
   // vectors should be registered
-  attrs.semantic_feature = Eigen::MatrixXd(5, 1);
+  attrs.semantic_feature = Eigen::MatrixXf(5, 1);
   EXPECT_TRUE(attrs.hasFeature());
   // matrices should be registered
-  attrs.semantic_feature = Eigen::MatrixXd(5, 3);
+  attrs.semantic_feature = Eigen::MatrixXf(5, 3);
   EXPECT_TRUE(attrs.hasFeature());
 }
 


### PR DESCRIPTION
@Schmluk realized that we actually probably want a single-precision attribute field for features / embeddings, not double-precision, lmk what you think