### PR TITLE
remove implicit bool conversion

### DIFF
--- a/include/spark_dsg/layer_prefix.h
+++ b/include/spark_dsg/layer_prefix.h
@@ -43,7 +43,6 @@
 namespace spark_dsg {
 
 struct LayerKey {
-  static constexpr LayerId UNKNOWN_LAYER = DsgLayers::UNKNOWN;
   LayerId layer;
   uint32_t prefix = 0;
   bool dynamic = false;
@@ -56,13 +55,13 @@ struct LayerKey {
 
   bool isParent(const LayerKey& other) const;
 
+  bool valid() const;
+
   bool operator==(const LayerKey& other) const;
 
   inline bool operator!=(const LayerKey& other) const {
     return !this->operator==(other);
   }
-
-  inline operator bool() const { return layer != UNKNOWN_LAYER; }
 };
 
 std::ostream& operator<<(std::ostream& out, const LayerKey& key);

--- a/src/dynamic_scene_graph.cpp
+++ b/src/dynamic_scene_graph.cpp
@@ -57,6 +57,12 @@ DynamicSceneGraph::LayerIds getDefaultLayerIds() {
 DynamicSceneGraph::DynamicSceneGraph() : DynamicSceneGraph(getDefaultLayerIds()) {}
 
 DynamicSceneGraph::DynamicSceneGraph(const LayerIds& layer_ids) : layer_ids(layer_ids) {
+  for (const auto layer_id : layer_ids) {
+    if (layer_id == DsgLayers::UNKNOWN) {
+      throw std::domain_error("cannot instantiate layer with unknown layer id!");
+    }
+  }
+
   if (layer_ids.empty()) {
     throw std::domain_error("scene graph cannot be initialized without layers");
   }
@@ -236,7 +242,7 @@ bool DynamicSceneGraph::insertEdge(NodeId source,
     return false;
   }
 
-  if (!source_key || !target_key) {
+  if (!source_key.valid() || !target_key.valid()) {
     return false;
   }
 
@@ -267,7 +273,7 @@ bool DynamicSceneGraph::insertParentEdge(NodeId source,
     return false;
   }
 
-  if (!source_key || !target_key) {
+  if (!source_key.valid() || !target_key.valid()) {
     return false;
   }
 
@@ -467,7 +473,7 @@ bool DynamicSceneGraph::removeEdge(NodeId source, NodeId target) {
     return false;
   }
 
-  if (!source_key || !target_key) {
+  if (!source_key.valid() || !target_key.valid()) {
     return false;
   }
 

--- a/src/layer_prefix.cpp
+++ b/src/layer_prefix.cpp
@@ -39,12 +39,16 @@
 
 namespace spark_dsg {
 
-LayerKey::LayerKey() : layer(LayerKey::UNKNOWN_LAYER) {}
+LayerKey::LayerKey() : layer(DsgLayers::UNKNOWN) {}
 
 LayerKey::LayerKey(LayerId layer_id) : layer(layer_id) {}
 
 LayerKey::LayerKey(LayerId layer_id, uint32_t prefix)
     : layer(layer_id), prefix(prefix), dynamic(true) {}
+
+bool LayerKey::isParent(const LayerKey& other) const { return layer > other.layer; }
+
+bool LayerKey::valid() const { return layer != DsgLayers::UNKNOWN; }
 
 bool LayerKey::operator==(const LayerKey& other) const {
   if (dynamic != other.dynamic) {
@@ -58,8 +62,6 @@ bool LayerKey::operator==(const LayerKey& other) const {
 
   return same_layer && prefix == other.prefix;
 }
-
-bool LayerKey::isParent(const LayerKey& other) const { return layer > other.layer; }
 
 std::ostream& operator<<(std::ostream& out, const LayerKey& key) {
   if (key.dynamic) {

--- a/src/scene_graph_utilities.cpp
+++ b/src/scene_graph_utilities.cpp
@@ -48,7 +48,7 @@ void getAncestorsOfLayer(const DynamicSceneGraph& graph,
     return;
   }
 
-  if (node->layer <= child_layer) {
+  if (node->layer <= child_layer.layer) {
     return;
   }
 

--- a/tests/utest_layer_prefix.cpp
+++ b/tests/utest_layer_prefix.cpp
@@ -65,13 +65,6 @@ TEST(LayerKeyTests, TestIsParent) {
   EXPECT_FALSE(key6.isParent(key4));
 }
 
-TEST(LayerKeyTests, TestKeyTruthValues) {
-  EXPECT_FALSE(LayerKey());
-  EXPECT_TRUE(LayerKey(1));
-  EXPECT_TRUE(LayerKey(2, 0));
-  EXPECT_TRUE(LayerKey(0));
-}
-
 TEST(LayerPrefixTests, TestMatches) {
   LayerPrefix a('a');
   EXPECT_TRUE(a.matches(NodeSymbol('a', 0)));


### PR DESCRIPTION
Fixes bug where using `LayerKey` in place of `LayerId` when accessing a layer casts the `LayerKey` to a `bool`