### PR TITLE
Feature/metadata

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,5 @@
 [flake8]
 max-line-length = 88
 extend-ignore = E203, W503
+per-file-ignores =
+    *__init__.py:F401,F403

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(spark_dsg VERSION 1.0.5)
+project(spark_dsg VERSION 1.0.6)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/include/spark_dsg/dynamic_scene_graph.h
+++ b/include/spark_dsg/dynamic_scene_graph.h
@@ -34,6 +34,7 @@
  * -------------------------------------------------------------------------- */
 #pragma once
 #include <Eigen/Core>
+#include <nlohmann/json.hpp>
 #include <type_traits>
 
 #include "spark_dsg/dynamic_scene_graph_layer.h"
@@ -410,20 +411,20 @@ class DynamicSceneGraph {
 
   /**
    * @brief Get number of static edges in the graph
-   * @return number of static edges in the graph
+   * @return Number of static edges in the graph
    */
   size_t numStaticEdges() const;
 
   /**
    * @brief Get number of dynamic edges in the graph
-   * @return number of dynamic edges in the graph
+   * @return Number of dynamic edges in the graph
    */
   size_t numDynamicEdges() const;
 
   /**
    * @brief Get whether or not the scene graph is empty
-   * @note the scene graph invariants make it so only nodes have to be checked
-   * @return true if the scene graph is empty
+   * @note The scene graph invariants make it so only nodes have to be checked
+   * @return True if the scene graph is empty
    */
   bool empty() const;
 
@@ -435,10 +436,10 @@ class DynamicSceneGraph {
   Eigen::Vector3d getPosition(NodeId node) const;
 
   /**
-   * @brief merge two nodes
-   * @param node_from node to remove
-   * @param node_to node to merge to
-   * @returns true if operation succeeded
+   * @brief Merge two nodes
+   * @param node_from Node to remove
+   * @param node_to Node to merge to
+   * @returns True if operation succeeded
    */
   bool mergeNodes(NodeId node_from, NodeId node_to);
 
@@ -457,7 +458,7 @@ class DynamicSceneGraph {
    * @note Will add the nodes and edges not previously added in current graph
    * @param other other graph to update from
    * @param config Configuration controlling merge behavior
-   * @returns true if merge was successful
+   * @returns True if merge was successful
    */
   bool mergeGraph(const DynamicSceneGraph& other, const GraphMergeConfig& config = {});
 
@@ -471,7 +472,7 @@ class DynamicSceneGraph {
   /**
    * @brief Get all new nodes in the graph
    * @param clear_new Clear new status for all new nodes up until this point
-   * @returns list of all new nodes
+   * @returns List of all new nodes
    */
   std::vector<NodeId> getNewNodes(bool clear_new = false);
 
@@ -490,12 +491,12 @@ class DynamicSceneGraph {
   std::vector<EdgeKey> getNewEdges(bool clear_new = false);
 
   /**
-   * @brief track which edges get used during a serialization update
+   * @brief Track which edges get used during a serialization update
    */
   void markEdgesAsStale();
 
   /**
-   * @brief remove edges that do not appear in serialization update
+   * @brief Remove edges that do not appear in serialization update
    */
   void removeAllStaleEdges();
 
@@ -514,7 +515,7 @@ class DynamicSceneGraph {
   void save(std::string filepath, bool include_mesh = true) const;
 
   /**
-   * @brief parse graph from binary or JSON file
+   * @brief Parse graph from binary or JSON file
    * @param filepath Complete path to file to read, including extension.
    * @returns Resulting parsed scene graph
    */
@@ -526,8 +527,11 @@ class DynamicSceneGraph {
 
   std::shared_ptr<Mesh> mesh() const;
 
-  //! current static layer ids in the graph
+  //! Current static layer ids in the graph
   const LayerIds layer_ids;
+
+  //! Any extra information about the graph
+  nlohmann::json metadata;
 
  protected:
   BaseLayer& layerFromKey(const LayerKey& key);

--- a/include/spark_dsg/edge_attributes.h
+++ b/include/spark_dsg/edge_attributes.h
@@ -34,6 +34,7 @@
  * -------------------------------------------------------------------------- */
 #pragma once
 #include <memory>
+#include <nlohmann/json.hpp>
 #include <ostream>
 
 #include "spark_dsg/serialization/attribute_registry.h"
@@ -76,6 +77,8 @@ struct EdgeAttributes {
   bool weighted;
   //! the weight of the edge
   double weight;
+  //! Arbitrary metadata about the edge
+  nlohmann::json metadata;
 
   /**
    * @brief output attribute information

--- a/include/spark_dsg/node_attributes.h
+++ b/include/spark_dsg/node_attributes.h
@@ -38,6 +38,7 @@
 #include <list>
 #include <map>
 #include <memory>
+#include <nlohmann/json.hpp>
 #include <optional>
 #include <ostream>
 #include <string>
@@ -113,6 +114,8 @@ struct NodeAttributes {
   bool is_active;
   //! whether the node was observed by Hydra, or added as a prediction
   bool is_predicted;
+  //! Arbitrary node metadata
+  nlohmann::json metadata;
 
   /**
    * @brief output attribute information

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>spark_dsg</name>
-  <version>1.0.5</version>
+  <version>1.0.6</version>
   <description>Dynamic Scene Graph (DSG) type definitions and core library code</description>
 
   <author email="na26933@mit.edu">Nathan Hughes</author>

--- a/python/bindings/include/spark_dsg/python/python_layer_view.h
+++ b/python/bindings/include/spark_dsg/python/python_layer_view.h
@@ -34,6 +34,7 @@
  * -------------------------------------------------------------------------- */
 #pragma once
 #include <spark_dsg/dynamic_scene_graph.h>
+#include <spark_dsg/node_symbol.h>
 
 #include "spark_dsg/python/scene_graph_iterators.h"
 
@@ -46,11 +47,11 @@ class LayerView {
   EdgeIter edges() const;
   size_t numNodes() const;
   size_t numEdges() const;
-  bool hasNode(NodeId node_id) const;
-  bool hasEdge(NodeId source, NodeId target) const;
-  const SceneGraphNode& getNode(NodeId node_id) const;
-  const SceneGraphEdge& getEdge(NodeId source, NodeId target) const;
-  Eigen::Vector3d getPosition(NodeId node_id) const;
+  bool hasNode(NodeSymbol node_id) const;
+  bool hasEdge(NodeSymbol source, NodeSymbol target) const;
+  const SceneGraphNode& getNode(NodeSymbol node_id) const;
+  const SceneGraphEdge& getEdge(NodeSymbol source, NodeSymbol target) const;
+  Eigen::Vector3d getPosition(NodeSymbol node_id) const;
 
   const LayerId id;
 

--- a/python/bindings/src/python_layer_view.cpp
+++ b/python/bindings/src/python_layer_view.cpp
@@ -48,21 +48,21 @@ size_t LayerView::numNodes() const { return layer_ref_.numNodes(); }
 
 size_t LayerView::numEdges() const { return layer_ref_.numEdges(); }
 
-bool LayerView::hasNode(NodeId node_id) const { return layer_ref_.hasNode(node_id); }
+bool LayerView::hasNode(NodeSymbol node_id) const { return layer_ref_.hasNode(node_id); }
 
-bool LayerView::hasEdge(NodeId source, NodeId target) const {
+bool LayerView::hasEdge(NodeSymbol source, NodeSymbol target) const {
   return layer_ref_.hasEdge(source, target);
 }
 
-const SceneGraphNode& LayerView::getNode(NodeId node_id) const {
+const SceneGraphNode& LayerView::getNode(NodeSymbol node_id) const {
   return layer_ref_.getNode(node_id);
 }
 
-const SceneGraphEdge& LayerView::getEdge(NodeId source, NodeId target) const {
+const SceneGraphEdge& LayerView::getEdge(NodeSymbol source, NodeSymbol target) const {
   return layer_ref_.getEdge(source, target);
 }
 
-Eigen::Vector3d LayerView::getPosition(NodeId node_id) const {
+Eigen::Vector3d LayerView::getPosition(NodeSymbol node_id) const {
   return layer_ref_.getNode(node_id).attributes().position;
 }
 

--- a/python/bindings/src/spark_dsg_bindings.cpp
+++ b/python/bindings/src/spark_dsg_bindings.cpp
@@ -759,6 +759,16 @@ PYBIND11_MODULE(_dsg_bindings, module) {
                   [](const std::filesystem::path& filepath) {
                     return DynamicSceneGraph::load(filepath);
                   })
+      .def("_get_metadata",
+           [](const DynamicSceneGraph& graph) {
+             std::stringstream ss;
+             ss << graph.metadata;
+             return ss.str();
+           })
+      .def("_set_metadata",
+           [](DynamicSceneGraph& graph, const std::string& data) {
+             graph.metadata = nlohmann::json::parse(data);
+           })
       .def_property(
           "layers",
           [](const DynamicSceneGraph& graph) {

--- a/python/bindings/src/spark_dsg_bindings.cpp
+++ b/python/bindings/src/spark_dsg_bindings.cpp
@@ -260,6 +260,16 @@ PYBIND11_MODULE(_dsg_bindings, module) {
       .def_readwrite("last_update_time_ns", &NodeAttributes::last_update_time_ns)
       .def_readwrite("is_active", &NodeAttributes::is_active)
       .def_readwrite("is_predicted", &NodeAttributes::is_predicted)
+      .def("_get_metadata",
+           [](const NodeAttributes& node) {
+             std::stringstream ss;
+             ss << node.metadata;
+             return ss.str();
+           })
+      .def("_set_metadata",
+           [](NodeAttributes& node, const std::string& data) {
+             node.metadata = nlohmann::json::parse(data);
+           })
       .def("__repr__", [](const NodeAttributes& attrs) {
         std::stringstream ss;
         ss << attrs;
@@ -386,7 +396,16 @@ PYBIND11_MODULE(_dsg_bindings, module) {
   py::class_<EdgeAttributes>(module, "EdgeAttributes")
       .def(py::init<>())
       .def_readwrite("weighted", &EdgeAttributes::weighted)
-      .def_readwrite("weight", &EdgeAttributes::weight);
+      .def_readwrite("weight", &EdgeAttributes::weight)
+      .def("_get_metadata",
+           [](const EdgeAttributes& edge) {
+             std::stringstream ss;
+             ss << edge.metadata;
+             return ss.str();
+           })
+      .def("_set_metadata", [](EdgeAttributes& edge, const std::string& data) {
+        edge.metadata = nlohmann::json::parse(data);
+      });
 
   /**************************************************************************************
    * Scene graph node

--- a/python/src/spark_dsg/__init__.py
+++ b/python/src/spark_dsg/__init__.py
@@ -33,18 +33,18 @@
 #
 #
 """The Spark-DSG package."""
-from spark_dsg._dsg_bindings import *  # NOQA
-from spark_dsg._dsg_bindings import (
-    compute_ancestor_bounding_box,
-    DsgLayers,
-    BoundingBoxType,
-    DynamicSceneGraph,
-    SceneGraphLayer,
-    LayerView,
-)
-from spark_dsg.torch_conversion import scene_graph_to_torch, scene_graph_layer_to_torch
-from spark_dsg.visualization import plot_scene_graph  # NOQA
-from spark_dsg.open3d_visualization import render_to_open3d  # NOQA
+import json
+import types
+
+from spark_dsg._dsg_bindings import *
+from spark_dsg._dsg_bindings import (BoundingBoxType, DsgLayers,
+                                     DynamicSceneGraph, LayerView,
+                                     SceneGraphLayer,
+                                     compute_ancestor_bounding_box)
+from spark_dsg.open3d_visualization import render_to_open3d
+from spark_dsg.torch_conversion import (scene_graph_layer_to_torch,
+                                        scene_graph_to_torch)
+from spark_dsg.visualization import plot_scene_graph
 
 
 def add_bounding_boxes_to_layer(
@@ -67,6 +67,43 @@ def add_bounding_boxes_to_layer(
         )
         node.attributes.bounding_box = bbox
 
+
+def _get_metadata(G):
+    """Get graph metadata."""
+    data_str = G._get_metadata()
+    metadata = json.loads(data_str)
+    metadata = dict() if metadata is None else metadata
+    return types.MappingProxyType(metadata)
+
+
+def _set_metadata(G, obj):
+    """Serialize and set graph metadata."""
+    G._set_metadata(json.dumps(obj))
+
+
+def _update_nested(contents, other):
+    for key, value in other.items():
+        if key not in contents:
+            contents[key] = {}
+
+        if isinstance(value, dict):
+            _update_nested(contents[key], value)
+        else:
+            contents[key] = value
+
+
+def _add_metadata(G, obj):
+    """Serialize and update metadata from passed object."""
+    data_str = G._get_metadata()
+    metadata = json.loads(data_str)
+    metadata = dict() if metadata is None else metadata
+    _update_nested(metadata, obj)
+    G._set_metadata(json.dumps(metadata))
+
+
+DynamicSceneGraph.metadata = property(_get_metadata)
+DynamicSceneGraph.set_metadata = _set_metadata
+DynamicSceneGraph.add_metadata = _add_metadata
 
 DynamicSceneGraph.to_torch = scene_graph_to_torch
 SceneGraphLayer.to_torch = scene_graph_layer_to_torch

--- a/python/src/spark_dsg/__init__.py
+++ b/python/src/spark_dsg/__init__.py
@@ -38,7 +38,8 @@ import types
 
 from spark_dsg._dsg_bindings import *
 from spark_dsg._dsg_bindings import (BoundingBoxType, DsgLayers,
-                                     DynamicSceneGraph, LayerView,
+                                     DynamicSceneGraph, EdgeAttributes,
+                                     LayerView, NodeAttributes,
                                      SceneGraphLayer,
                                      compute_ancestor_bounding_box)
 from spark_dsg.open3d_visualization import render_to_open3d
@@ -68,17 +69,17 @@ def add_bounding_boxes_to_layer(
         node.attributes.bounding_box = bbox
 
 
-def _get_metadata(G):
+def _get_metadata(obj):
     """Get graph metadata."""
-    data_str = G._get_metadata()
+    data_str = obj._get_metadata()
     metadata = json.loads(data_str)
     metadata = dict() if metadata is None else metadata
     return types.MappingProxyType(metadata)
 
 
-def _set_metadata(G, obj):
+def _set_metadata(obj, data):
     """Serialize and set graph metadata."""
-    G._set_metadata(json.dumps(obj))
+    obj._set_metadata(json.dumps(data))
 
 
 def _update_nested(contents, other):
@@ -92,18 +93,24 @@ def _update_nested(contents, other):
             contents[key] = value
 
 
-def _add_metadata(G, obj):
+def _add_metadata(obj, data):
     """Serialize and update metadata from passed object."""
-    data_str = G._get_metadata()
+    data_str = obj._get_metadata()
     metadata = json.loads(data_str)
     metadata = dict() if metadata is None else metadata
-    _update_nested(metadata, obj)
-    G._set_metadata(json.dumps(metadata))
+    _update_nested(metadata, data)
+    obj._set_metadata(json.dumps(metadata))
 
 
-DynamicSceneGraph.metadata = property(_get_metadata)
-DynamicSceneGraph.set_metadata = _set_metadata
-DynamicSceneGraph.add_metadata = _add_metadata
+def _add_metadata_interface(obj):
+    obj.metadata = property(_get_metadata)
+    obj.set_metadata = _set_metadata
+    obj.add_metadata = _add_metadata
+
+
+_add_metadata_interface(DynamicSceneGraph)
+_add_metadata_interface(NodeAttributes)
+_add_metadata_interface(EdgeAttributes)
 
 DynamicSceneGraph.to_torch = scene_graph_to_torch
 SceneGraphLayer.to_torch = scene_graph_layer_to_torch

--- a/python/tests/test_bindings.py
+++ b/python/tests/test_bindings.py
@@ -33,8 +33,6 @@
 #
 #
 """Test that the bindings are working appropriately."""
-import json
-
 import numpy as np
 import spark_dsg as dsg
 
@@ -307,7 +305,7 @@ def test_node_counts(resource_dir):
 
 
 def test_graph_metadata(tmp_path):
-    """Test that graph metadat works as expected."""
+    """Test that graph metadata works as expected."""
     G = dsg.DynamicSceneGraph()
     G.add_metadata({"foo": 5})
     G.add_metadata({"bar": [1, 2, 3, 4, 5]})
@@ -323,9 +321,24 @@ def test_graph_metadata(tmp_path):
     }
 
     G.add_metadata({"something": {"b": 643.0, "other": "foo"}})
-    print(G.metadata)
     assert G.metadata == {
         "foo": 5,
         "bar": [1, 2, 3, 4, 5],
         "something": {"a": 13, "b": 643.0, "c": "world", "other": "foo"},
     }
+
+
+def test_attribute_metadata(tmp_path):
+    """Test that attribute metadata works as expected."""
+    G = dsg.DynamicSceneGraph()
+
+    attrs = dsg.ObjectNodeAttributes()
+    attrs.add_metadata({"test": {"a": 5, "c": "hello"}})
+    attrs.add_metadata({"test": {"a": 6, "b": 42.0}})
+    G.add_node(dsg.DsgLayers.OBJECTS, dsg.NodeSymbol("O", 1), attrs)
+
+    graph_path = tmp_path / "graph.json"
+    G.save(graph_path)
+    G_new = dsg.DynamicSceneGraph.load(graph_path)
+    new_attrs = G_new.get_node(dsg.NodeSymbol("O", 1)).attributes
+    assert new_attrs.metadata == {"test": {"a": 6, "b": 42.0, "c": "hello"}}

--- a/python/tests/test_bindings.py
+++ b/python/tests/test_bindings.py
@@ -33,8 +33,10 @@
 #
 #
 """Test that the bindings are working appropriately."""
-import spark_dsg as dsg
+import json
+
 import numpy as np
+import spark_dsg as dsg
 
 
 def test_empty_graph():
@@ -302,3 +304,28 @@ def test_node_counts(resource_dir):
     assert node_type_counts["R"] == G.get_layer(dsg.DsgLayers.ROOMS).num_nodes()
     assert "B" in node_type_counts
     assert node_type_counts["B"] == G.get_layer(dsg.DsgLayers.BUILDINGS).num_nodes()
+
+
+def test_graph_metadata(tmp_path):
+    """Test that graph metadat works as expected."""
+    G = dsg.DynamicSceneGraph()
+    G.add_metadata({"foo": 5})
+    G.add_metadata({"bar": [1, 2, 3, 4, 5]})
+    G.add_metadata({"something": {"a": 13, "b": 42.0, "c": "world"}})
+
+    graph_path = tmp_path / "graph.json"
+    G.save(graph_path)
+    G_new = dsg.DynamicSceneGraph.load(graph_path)
+    assert G_new.metadata == {
+        "foo": 5,
+        "bar": [1, 2, 3, 4, 5],
+        "something": {"a": 13, "b": 42.0, "c": "world"},
+    }
+
+    G.add_metadata({"something": {"b": 643.0, "other": "foo"}})
+    print(G.metadata)
+    assert G.metadata == {
+        "foo": 5,
+        "bar": [1, 2, 3, 4, 5],
+        "something": {"a": 13, "b": 643.0, "c": "world", "other": "foo"},
+    }

--- a/python/tests/test_networkx.py
+++ b/python/tests/test_networkx.py
@@ -33,9 +33,20 @@
 #
 #
 """Test that networkx conversion works as expected."""
+import importlib
+
+import numpy as np
+import pytest
 import spark_dsg as dsg
 import spark_dsg.networkx as dsg_nx
-import numpy as np
+
+
+def _has_networkx():
+    try:
+        importlib.import_module("networkx")
+        return True
+    except ImportError:
+        return False
 
 
 def _check_attribute_validity(G_nx):
@@ -49,6 +60,7 @@ def _check_attribute_validity(G_nx):
         assert "weighted" in G_nx[edge[0]][edge[1]]
 
 
+@pytest.mark.skipif(not _has_networkx(), reason="requires networkx")
 def test_static_graph_conversion(resource_dir):
     """Test that graph conversion is exact."""
     dsg_path = resource_dir / "apartment_dsg.json"
@@ -62,6 +74,7 @@ def test_static_graph_conversion(resource_dir):
     _check_attribute_validity(G_nx)
 
 
+@pytest.mark.skipif(not _has_networkx(), reason="requires networkx")
 def test_full_graph_conversion(resource_dir):
     """Test that graph conversion is exact."""
     dsg_path = resource_dir / "apartment_dsg.json"
@@ -81,6 +94,7 @@ def test_full_graph_conversion(resource_dir):
     _check_attribute_validity(G_nx)
 
 
+@pytest.mark.skipif(not _has_networkx(), reason="requires networkx")
 def test_layer_conversion(resource_dir):
     """Test that layer conversion is exact."""
     dsg_path = resource_dir / "apartment_dsg.json"

--- a/src/dynamic_scene_graph.cpp
+++ b/src/dynamic_scene_graph.cpp
@@ -56,7 +56,8 @@ DynamicSceneGraph::LayerIds getDefaultLayerIds() {
 
 DynamicSceneGraph::DynamicSceneGraph() : DynamicSceneGraph(getDefaultLayerIds()) {}
 
-DynamicSceneGraph::DynamicSceneGraph(const LayerIds& layer_ids) : layer_ids(layer_ids) {
+DynamicSceneGraph::DynamicSceneGraph(const LayerIds& layer_ids)
+    : layer_ids(layer_ids), metadata(nlohmann::json::object()) {
   for (const auto layer_id : layer_ids) {
     if (layer_id == DsgLayers::UNKNOWN) {
       throw std::domain_error("cannot instantiate layer with unknown layer id!");

--- a/src/serialization/graph_json_serialization.cpp
+++ b/src/serialization/graph_json_serialization.cpp
@@ -116,6 +116,7 @@ std::string writeGraph(const DynamicSceneGraph& graph, bool include_mesh) {
   record["nodes"] = nlohmann::json::array();
   record["edges"] = nlohmann::json::array();
   record["layer_ids"] = graph.layer_ids;
+  record["metadata"] = graph.metadata;
 
   for (const auto& id_layer_pair : graph.layers()) {
     for (const auto& id_node_pair : id_layer_pair.second->nodes()) {
@@ -177,6 +178,10 @@ DynamicSceneGraph::Ptr readGraph(const std::string& contents) {
 
   const auto layer_ids = record.at("layer_ids").get<DynamicSceneGraph::LayerIds>();
   auto graph = std::make_shared<DynamicSceneGraph>(layer_ids);
+
+  if (record.contains("metadata")) {
+    graph->metadata = record["metadata"];
+  }
 
   for (const auto& node : record.at("nodes")) {
     read_node_from_json(node_factory, node, *graph);


### PR DESCRIPTION
Adds metadata fields to `DynamicSceneGraph`, `NodeAttributes` and `EdgeAttributes`. Notes:
- Requires a version bump for serialization
- They (somewhat intentionally) are not very ergonomic or efficient (to encourage eventually codifying a common metadata field into an actual node or edge attribute)
- Reading or updating the metadata on the python side involves serializing the json to a string and then deserializing it (which can be slow when there's a lot of metadata)
- Updates the bindings and python unit tests slightly for unrelated reasons