### PR TITLE
Add str function for nodesymbol to enable parentheses-less node symbols

### DIFF
--- a/python/bindings/src/spark_dsg_bindings.cpp
+++ b/python/bindings/src/spark_dsg_bindings.cpp
@@ -184,7 +184,7 @@ PYBIND11_MODULE(_dsg_bindings, module) {
       .def("__repr__", [](const NodeSymbol& ns) { return ns.str(false); })
       .def("__hash__",
            [](const NodeSymbol& symbol) { return static_cast<NodeId>(symbol); })
-      .def("str", &NodeSymbol::str, "literal"_a = true);
+      .def("str", &NodeSymbol::str, "literal"_a = true)
       .def(pybind11::self == pybind11::self)
       .def(pybind11::self != pybind11::self);
 


### PR DESCRIPTION
I needed a way to get the node symbol to print without parentheses in python. This works for my use-case, but let me know if you want to handle this differently. 