### PR TITLE
deprecate get_layer_id in favor of get_layer_key

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,22 +44,17 @@ jobs:
           pip install torch --index-url https://download.pytorch.org/whl/cpu
           pip install pytest networkx torch_geometric
           pytest ${{github.workspace}}/python/tests
-  ros1:
+  ros2:
     runs-on: ubuntu-latest
-    container: ros:noetic-ros-base-focal
+    container: ros:jazzy-ros-base
     steps:
       - uses: actions/checkout@v4
         with: {path: src/spark_dsg}
       - name: Dependencies
         run: |
-          apt update && apt install -y python3-wstool python3-catkin-tools python3-vcstool git
-          rosdep update --rosdistro noetic && rosdep install --rosdistro noetic --from-paths src --ignore-src -r -y
-      - name: Configure
-        run: |
-          catkin init
-          catkin config --extend /opt/ros/noetic
-          catkin config -DCMAKE_BUILD_TYPE=Release -DSPARK_DSG_BUILD_EXAMPLES=ON
+          apt update && apt install -y python3-vcstool git
+          rosdep update --rosdistro jazzy && rosdep install --rosdistro jazzy --from-paths src --ignore-src -r -y
       - name: Build
-        run: catkin build spark_dsg
+        run: colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release -DSPARK_DSG_BUILD_EXAMPLES=ON
       - name: Test
-        run: catkin test spark_dsg
+        run: colcon test

--- a/python/bindings/src/spark_dsg_bindings.cpp
+++ b/python/bindings/src/spark_dsg_bindings.cpp
@@ -934,16 +934,7 @@ PYBIND11_MODULE(_dsg_bindings, module) {
           "mesh",
           [](const DynamicSceneGraph& graph) { return graph.mesh(); },
           [](DynamicSceneGraph& graph, const Mesh::Ptr& mesh) { graph.setMesh(mesh); })
-      .def(
-          "get_layer_id",
-          [](const DynamicSceneGraph& graph,
-             const std::string& name) -> std::optional<LayerKey> {
-            const auto& name_map = graph.layer_names();
-            auto iter = name_map.find(name);
-            return iter == name_map.end() ? std::nullopt
-                                          : std::optional<LayerKey>({iter->second});
-          },
-          "name"_a)
+      .def("get_layer_key", &DynamicSceneGraph::getLayerKey, "name"_a)
       .def("clone", &DynamicSceneGraph::clone)
       .def("transform",
            [](DynamicSceneGraph& G, const Eigen::Matrix4d& mat) {

--- a/python/spark_dsg/__init__.py
+++ b/python/spark_dsg/__init__.py
@@ -39,14 +39,19 @@ import types
 import warnings
 
 from spark_dsg._dsg_bindings import *
-from spark_dsg._dsg_bindings import (BoundingBoxType, DsgLayers,
-                                     DynamicSceneGraph, EdgeAttributes,
-                                     LayerKey, LayerView, NodeAttributes,
-                                     SceneGraphLayer,
-                                     compute_ancestor_bounding_box)
+from spark_dsg._dsg_bindings import (
+    BoundingBoxType,
+    DsgLayers,
+    DynamicSceneGraph,
+    EdgeAttributes,
+    LayerKey,
+    LayerView,
+    NodeAttributes,
+    SceneGraphLayer,
+    compute_ancestor_bounding_box,
+)
 from spark_dsg.open3d_visualization import render_to_open3d
-from spark_dsg.torch_conversion import (scene_graph_layer_to_torch,
-                                        scene_graph_to_torch)
+from spark_dsg.torch_conversion import scene_graph_layer_to_torch, scene_graph_to_torch
 from spark_dsg.visualization import plot_scene_graph
 
 

--- a/python/spark_dsg/__init__.py
+++ b/python/spark_dsg/__init__.py
@@ -36,21 +36,17 @@
 
 import json
 import types
+import warnings
 
 from spark_dsg._dsg_bindings import *
-from spark_dsg._dsg_bindings import (
-    BoundingBoxType,
-    DsgLayers,
-    DynamicSceneGraph,
-    EdgeAttributes,
-    LayerKey,
-    LayerView,
-    NodeAttributes,
-    SceneGraphLayer,
-    compute_ancestor_bounding_box,
-)
+from spark_dsg._dsg_bindings import (BoundingBoxType, DsgLayers,
+                                     DynamicSceneGraph, EdgeAttributes,
+                                     LayerKey, LayerView, NodeAttributes,
+                                     SceneGraphLayer,
+                                     compute_ancestor_bounding_box)
 from spark_dsg.open3d_visualization import render_to_open3d
-from spark_dsg.torch_conversion import scene_graph_layer_to_torch, scene_graph_to_torch
+from spark_dsg.torch_conversion import (scene_graph_layer_to_torch,
+                                        scene_graph_to_torch)
 from spark_dsg.visualization import plot_scene_graph
 
 
@@ -101,12 +97,22 @@ def _hash_layerkey(key):
     return hash((key.layer, key.partition))
 
 
+def _get_layer_id(graph, name):
+    warnings.warn(
+        "'get_layer_id' is deprecated. Please use 'get_layer_key'",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return graph.get_layer_key(name)
+
+
 LayerKey.__hash__ = _hash_layerkey
 
 _add_metadata_interface(DynamicSceneGraph)
 _add_metadata_interface(NodeAttributes)
 _add_metadata_interface(EdgeAttributes)
 
+DynamicSceneGraph.get_layer_id = _get_layer_id
 DynamicSceneGraph.to_torch = scene_graph_to_torch
 SceneGraphLayer.to_torch = scene_graph_layer_to_torch
 LayerView.to_torch = scene_graph_layer_to_torch


### PR DESCRIPTION
Finally getting around to fixing the confusing binding name for `get_layer_id`