### PR TITLE
Fix Open3D Visualizer

### DIFF
--- a/python/spark_dsg/open3d_visualization.py
+++ b/python/spark_dsg/open3d_visualization.py
@@ -175,7 +175,7 @@ class RemoteVisualizer:
 
             if part.id == places_lid:
                 self._update_layer_geometries(part, offset)
-                offset += layer.num_nodes()
+                offset += part.num_nodes()
 
         # prune points and colors to just the nodes we've added
         self._points = self._points[:offset, :]


### PR DESCRIPTION
This fix allows the Open3D visualizer to run, but the places layers still doesn't seem to be handled correctly. I don't know if this is an issue with the visualizer or Hydra when recording the .json files. 

For example, scene graphs recently generated with Hydra in ROS2 doesn't display the 2d places while scene graphs generated in the past display the 2d places. Attached is one of the problematic jsons.

[newer_dsg.json](https://github.com/user-attachments/files/21974624/newer_dsg.json)