### PR TITLE
Feature/memory tracking

### DIFF
--- a/include/spark_dsg/edge_attributes.h
+++ b/include/spark_dsg/edge_attributes.h
@@ -94,6 +94,11 @@ struct EdgeAttributes {
     return registrationImpl();
   }
 
+  /**
+   * @brief Estimate the memory usage of the edge attributes in bytes.
+   */
+  virtual size_t memoryUsage() const;
+
  protected:
   //! actually output information to the std::ostream
   virtual void fill_ostream(std::ostream& out) const;

--- a/include/spark_dsg/edge_container.h
+++ b/include/spark_dsg/edge_container.h
@@ -111,6 +111,11 @@ struct EdgeContainer {
   mutable EdgeStatusMap edge_status;
   mutable std::map<EdgeKey, bool> stale_edges;
 
+  /**
+   * @brief Get memory usage of the edge container in bytes.
+   */
+  size_t memoryUsage() const;
+
  protected:
   Edge* find(const EdgeKey& key) const;
 };

--- a/include/spark_dsg/mesh.h
+++ b/include/spark_dsg/mesh.h
@@ -222,6 +222,11 @@ class Mesh {
    */
   static Ptr load(std::filesystem::path filepath);
 
+  /**
+   * @brief Get memory usage of the mesh in bytes.
+   */
+  size_t memoryUsage() const;
+
   // ------ Modification ------
 
   /**
@@ -264,11 +269,6 @@ class Mesh {
    * @returns The current mesh
    */
   Mesh& operator+=(const Mesh& other);
-
-  /**
-   * @brief Get memory size
-   */
-  size_t totalBytes() const;
 
  public:
   const bool has_colors;

--- a/include/spark_dsg/metadata.h
+++ b/include/spark_dsg/metadata.h
@@ -45,6 +45,11 @@ struct Metadata {
   void set(const nlohmann::json& new_metadata);
   void add(const nlohmann::json& to_add);
 
+  /**
+   * @brief Estimate the memory usage of the metadata in bytes.
+   */
+  size_t memoryUsage() const;
+
  private:
   nlohmann::json contents_;
 };

--- a/include/spark_dsg/node_attributes.h
+++ b/include/spark_dsg/node_attributes.h
@@ -133,6 +133,11 @@ struct NodeAttributes {
     return registrationImpl();
   }
 
+  /**
+   * @brief Estimate the memory usage of the node attributes in bytes.
+   */
+  virtual size_t memoryUsage() const;
+
  protected:
   //! actually output information to the std::ostream
   virtual std::ostream& fill_ostream(std::ostream& out) const;

--- a/include/spark_dsg/scene_graph.h
+++ b/include/spark_dsg/scene_graph.h
@@ -479,6 +479,9 @@ class SceneGraph {
   //! @brief Get the mesh associated with the scene graph
   std::shared_ptr<Mesh> mesh() const;
 
+  //! @brief Estimate the memory usage of the scene graph in bytes.
+  size_t memoryUsage() const;
+
   //! Any extra information about the graph
   Metadata metadata;
 

--- a/include/spark_dsg/scene_graph_layer.h
+++ b/include/spark_dsg/scene_graph_layer.h
@@ -284,6 +284,11 @@ class SceneGraphLayer {
   //! ID of the layer
   const LayerKey id;
 
+  /**
+   * @brief Get memory usage of the layer in bytes.
+   */
+  size_t memoryUsage() const;
+
  protected:
   void reset();
 

--- a/include/spark_dsg/scene_graph_node.h
+++ b/include/spark_dsg/scene_graph_node.h
@@ -149,6 +149,11 @@ class SceneGraphNode {
     return dynamic_cast<Derived*>(attributes_.get());
   }
 
+  /**
+   * @brief Estimate the memory usage of the node in bytes.
+   */
+  size_t memoryUsage() const;
+
   //! ID of the node
   const NodeId id;
   //! ID of the layer the node belongs to

--- a/python/bindings/src/mesh.cpp
+++ b/python/bindings/src/mesh.cpp
@@ -197,7 +197,7 @@ void init_mesh(py::module_& m) {
           "rotation"_a = Eigen::Matrix3d::Identity(),
           "translation"_a = Eigen::Vector3d::Zero())
       .def("append", &Mesh::append)
-      .def("total_bytes", &Mesh::totalBytes)
+      .def("memory_usage", &Mesh::memoryUsage)
       .def(py::self += py::self);
 }
 

--- a/src/edge_attributes.cpp
+++ b/src/edge_attributes.cpp
@@ -78,4 +78,11 @@ bool EdgeAttributes::is_equal(const EdgeAttributes& other) const {
   return weighted == other.weighted && weight == other.weight;
 }
 
+size_t EdgeAttributes::memoryUsage() const {
+  size_t total_size = sizeof(EdgeAttributes);
+  // Metadata size (avoid double counting the Metadata struct itself).
+  total_size += metadata.memoryUsage() - sizeof(Metadata);
+  return total_size;
+}
+
 }  // namespace spark_dsg

--- a/src/edge_container.cpp
+++ b/src/edge_container.cpp
@@ -157,4 +157,20 @@ Edge* EdgeContainer::find(const EdgeKey& key) const {
   return const_cast<SceneGraphEdge*>(&iter->second);
 }
 
+size_t EdgeContainer::memoryUsage() const {
+  size_t total_size = sizeof(EdgeContainer);
+  // Edges and attributes.
+  total_size += edges.size() * sizeof(EdgeKey);
+  for (const auto& key_edge_pair : edges) {
+    total_size += sizeof(SceneGraphEdge);
+    if (key_edge_pair.second.info) {
+      total_size += key_edge_pair.second.info->memoryUsage();
+    }
+  }
+  // Status and stale maps.
+  total_size += edge_status.size() * (sizeof(EdgeKey) + sizeof(EdgeStatus));
+  total_size += stale_edges.size() * (sizeof(EdgeKey) + sizeof(bool));
+  return total_size;
+}
+
 }  // namespace spark_dsg

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -277,14 +277,19 @@ Mesh& Mesh::operator+=(const Mesh& other) {
   return *this;
 }
 
-size_t Mesh::totalBytes() const {
-  const auto point_bytes = 3 * sizeof(float) * points.size();
-  const auto color_bytes = sizeof(Color) * colors.size();
-  const auto stamp_bytes =
-      sizeof(Timestamp) * (stamps.size() + first_seen_stamps.size());
-  const auto label_bytes = sizeof(Label) * labels.size();
-  const auto face_bytes = 3 * sizeof(uint64_t) * faces.size();
-  return point_bytes + color_bytes + stamp_bytes + label_bytes + face_bytes;
+/**
+ * @brief Get memory usage of the mesh in bytes.
+ */
+size_t Mesh::memoryUsage() const {
+  // Static parts.
+  size_t total_bytes = sizeof(Mesh);
+  total_bytes += sizeof(Pos) * points.size();
+  total_bytes += sizeof(Color) * colors.size();
+  total_bytes += sizeof(Timestamp) * stamps.size();
+  total_bytes += sizeof(Timestamp) * first_seen_stamps.size();
+  total_bytes += sizeof(Label) * labels.size();
+  total_bytes += sizeof(Face) * faces.size();
+  return total_bytes;
 }
 
 bool operator==(const Mesh& lhs, const Mesh& rhs) {

--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -64,4 +64,16 @@ void Metadata::set(const nlohmann::json& new_metadata) { contents_ = new_metadat
 
 void Metadata::add(const nlohmann::json& to_add) { updateNested(contents_, to_add); }
 
+size_t Metadata::memoryUsage() const {
+  // Estimate memory usage of the JSON contents through serialization.
+  // TODO(lschmid): This is not a very clean method but at least does not ignore the
+  // meta data.
+  size_t total_size = sizeof(Metadata);
+  const std::string serialized = contents_.dump();
+  if (serialized == "{}") {
+    return total_size;
+  }
+  return total_size + serialized.size();
+}
+
 }  // namespace spark_dsg

--- a/src/node_attributes.cpp
+++ b/src/node_attributes.cpp
@@ -165,16 +165,12 @@ NodeAttributes::Ptr SemanticNodeAttributes::clone() const {
 }
 
 size_t NodeAttributes::memoryUsage() const {
-  // Simply dispatch serialization to estimate the attributes size. Not perfect but
-  // should be ok.
+  // By default simply dispatch serialization to estimate the attributes size. Not
+  // perfect but should be ok.
   std::vector<uint8_t> buffer;
   serialization::BinarySerializer serializer(&buffer);
   serializer.write(*this);
-  size_t total_size = buffer.size();
-
-  // Metadata size (avoid double counting the Metadata struct itself).
-  total_size += metadata.memoryUsage() - sizeof(Metadata);
-  return total_size;
+  return buffer.size();
 }
 
 void SemanticNodeAttributes::transform(const Eigen::Isometry3d& transform) {

--- a/src/node_attributes.cpp
+++ b/src/node_attributes.cpp
@@ -164,6 +164,19 @@ NodeAttributes::Ptr SemanticNodeAttributes::clone() const {
   return std::make_unique<SemanticNodeAttributes>(*this);
 }
 
+size_t NodeAttributes::memoryUsage() const {
+  // Simply dispatch serialization to estimate the attributes size. Not perfect but
+  // should be ok.
+  std::vector<uint8_t> buffer;
+  serialization::BinarySerializer serializer(&buffer);
+  serializer.write(*this);
+  size_t total_size = buffer.size();
+
+  // Metadata size (avoid double counting the Metadata struct itself).
+  total_size += metadata.memoryUsage() - sizeof(Metadata);
+  return total_size;
+}
+
 void SemanticNodeAttributes::transform(const Eigen::Isometry3d& transform) {
   NodeAttributes::transform(transform);
   bounding_box.transform(transform);

--- a/src/scene_graph_layer.cpp
+++ b/src/scene_graph_layer.cpp
@@ -390,6 +390,24 @@ void SceneGraphLayer::transform(const Eigen::Isometry3d& transform) {
   }
 }
 
+size_t SceneGraphLayer::memoryUsage() const {
+  size_t total_memory = sizeof(*this);
+
+  // Estimate memory usage of nodes.
+  total_memory += nodes_.size() * (sizeof(NodeId) + sizeof(Node::Ptr));
+  for (const auto& [node_id, node] : nodes_) {
+    total_memory += node->memoryUsage();
+  }
+
+  // Estimate memory usage of edges.
+  total_memory += edges_.memoryUsage();
+
+  // Estimate memory usage of nodes status map.
+  total_memory += nodes_status_.size() * (sizeof(NodeId) + sizeof(NodeStatus));
+
+  return total_memory;
+}
+
 namespace graph_utilities {
 
 using LayerGraphTraits = graph_traits<SceneGraphLayer>;

--- a/src/scene_graph_node.cpp
+++ b/src/scene_graph_node.cpp
@@ -74,4 +74,19 @@ std::vector<NodeId> SceneGraphNode::connections() const {
   return to_return;
 }
 
+size_t SceneGraphNode::memoryUsage() const {
+  size_t total_size = sizeof(SceneGraphNode);
+  // Attributes size.
+  if (attributes_) {
+    total_size += attributes_->memoryUsage();
+  }
+
+  // Connected nodes size.
+  total_size += siblings_.size() * sizeof(NodeId);
+  total_size += children_.size() * sizeof(NodeId);
+  total_size += parents_.size() * sizeof(NodeId);
+
+  return total_size;
+}
+
 }  // namespace spark_dsg

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(
   utest_edge_container.cpp
   utest_graph_utilities_layer.cpp
   utest_labelspace.cpp
+  utest_memory_usage.cpp
   utest_mesh.cpp
   utest_metadata.cpp
   utest_node_attributes.cpp

--- a/tests/utest_memory_usage.cpp
+++ b/tests/utest_memory_usage.cpp
@@ -1,0 +1,271 @@
+/* -----------------------------------------------------------------------------
+ * Copyright 2022 Massachusetts Institute of Technology.
+ * All Rights Reserved
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  1. Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *
+ *  2. Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Research was sponsored by the United States Air Force Research Laboratory and
+ * the United States Air Force Artificial Intelligence Accelerator and was
+ * accomplished under Cooperative Agreement Number FA8750-19-2-1000. The views
+ * and conclusions contained in this document are those of the authors and should
+ * not be interpreted as representing the official policies, either expressed or
+ * implied, of the United States Air Force or the U.S. Government. The U.S.
+ * Government is authorized to reproduce and distribute reprints for Government
+ * purposes notwithstanding any copyright notation herein.
+ * -------------------------------------------------------------------------- */
+#include <gtest/gtest.h>
+#include <spark_dsg/edge_attributes.h>
+#include <spark_dsg/edge_container.h>
+#include <spark_dsg/mesh.h>
+#include <spark_dsg/metadata.h>
+#include <spark_dsg/node_attributes.h>
+#include <spark_dsg/scene_graph.h>
+#include <spark_dsg/scene_graph_layer.h>
+#include <spark_dsg/scene_graph_node.h>
+#include <spark_dsg/serialization/graph_binary_serialization.h>
+
+#include "spark_dsg/logging.h"
+
+// TODO(lschmid): These tests are a quick sanity check and might break on different
+// platforms or with some future changes.
+
+namespace spark_dsg::tests {
+
+TEST(MemoryUsage, Mesh) {
+  Mesh mesh;
+  size_t expected_size = sizeof(Mesh);  // 160 bytes
+  EXPECT_EQ(mesh.memoryUsage(), expected_size);
+
+  mesh.points.resize(1000);
+  expected_size += sizeof(Mesh::Pos) * 1000;  // 12160 bytes
+  EXPECT_EQ(mesh.memoryUsage(), expected_size);
+
+  mesh.colors.resize(1000);
+  expected_size += sizeof(Color) * 1000;  // 28160 bytes
+  EXPECT_EQ(mesh.memoryUsage(), expected_size);
+}
+
+TEST(MemoryUsage, Metadata) {
+  Metadata metadata;
+  size_t expected_size = sizeof(Metadata);  // 16 bytes.
+  EXPECT_EQ(metadata.memoryUsage(), expected_size);
+
+  nlohmann::json contents;
+  contents["key1"] = "value1";
+  contents["key2"] = 42;
+  contents["nested"] = {{"nkey1", "nvalue1"}, {"nkey2", 3.14}};
+  metadata.set(contents);
+
+  expected_size += contents.dump().size();  // 85 bytes.
+  EXPECT_EQ(metadata.memoryUsage(), expected_size);
+}
+
+TEST(MemoryUsage, EdgeAttributes) {
+  EdgeAttributes attrs;
+  size_t expected_size = sizeof(EdgeAttributes);  // 40 bytes.
+  EXPECT_EQ(attrs.memoryUsage(), expected_size);
+
+  nlohmann::json meta_contents;
+  meta_contents["description"] = "Test edge";
+  meta_contents["weight"] = 2.5;
+  attrs.metadata.set(meta_contents);
+
+  expected_size += meta_contents.dump().size();  // 80 bytes
+  EXPECT_EQ(attrs.memoryUsage(), expected_size);
+}
+
+TEST(MemoryUsage, EdgeContainer) {
+  EdgeContainer edge_container;
+  size_t expected_size = sizeof(EdgeContainer);  // 144 bytes
+  EXPECT_EQ(edge_container.memoryUsage(), expected_size);
+
+  // Add some edges
+  for (size_t i = 0; i < 100; ++i) {
+    edge_container.insert(i, i + 1, std::make_unique<EdgeAttributes>(i * 0.1));
+  }
+  expected_size += 100 * 100;
+  EXPECT_EQ(edge_container.memoryUsage(), expected_size);
+}
+
+TEST(MemoryUsage, NodeAttributes) {
+  NodeAttributes attrs;
+  size_t expected_size = 47;
+  EXPECT_EQ(attrs.memoryUsage(), expected_size);
+
+  // Metadata.
+  nlohmann::json meta_contents;
+  meta_contents["type"] = "Test node";
+  meta_contents["value"] = 123;
+  attrs.metadata.set(meta_contents);
+  expected_size = 109;
+  EXPECT_EQ(attrs.memoryUsage(), expected_size);
+
+  // Semantic node attributes.
+  SemanticNodeAttributes sem_attrs;
+  expected_size = 196;
+  EXPECT_EQ(sem_attrs.memoryUsage(), expected_size);
+
+  sem_attrs.name = "Test Semantic Node";
+  sem_attrs.semantic_feature.resize(128, 64);
+  expected_size = 41174;
+  EXPECT_EQ(sem_attrs.memoryUsage(), expected_size);
+
+  // Object noed attributes.
+  ObjectNodeAttributes obj_attrs;
+  expected_size = 243;
+  EXPECT_EQ(obj_attrs.memoryUsage(), expected_size);
+  obj_attrs.mesh_connections.resize(500);
+
+  // NOTE(lschmid): The serialization uses up an extra byte per number for the type, so
+  // a bit more than the true memory size.
+  expected_size += 9 * 500;  // 4743 bytes.
+  EXPECT_EQ(obj_attrs.memoryUsage(), expected_size);
+}
+
+TEST(MemoryUsage, SceneGraphNode) {
+  SceneGraphNode node(1, {0, 0}, std::make_unique<NodeAttributes>());
+  size_t expected_size = 231;
+  EXPECT_EQ(node.memoryUsage(), expected_size);
+
+  // Add attributes
+  SceneGraphNode node2(2, {0, 0}, std::make_unique<SemanticNodeAttributes>());
+  node2.attributes<SemanticNodeAttributes>().semantic_feature.resize(128, 64);
+  expected_size = 41340;
+  EXPECT_EQ(node2.memoryUsage(), expected_size);
+}
+
+TEST(MemoryUsage, SceneGraphLayer) {
+  SceneGraphLayer layer(LayerKey{0, 0});
+  size_t expected_size = 408;
+  EXPECT_EQ(layer.memoryUsage(), expected_size);
+
+  // Add some nodes.
+  for (size_t i = 0; i < 50; ++i) {
+    layer.emplaceNode(i, std::make_unique<NodeAttributes>());
+  }
+  expected_size += 50 * 259;  // 13358 bytes
+  EXPECT_EQ(layer.memoryUsage(), expected_size);
+
+  // Add some edges.
+  for (size_t i = 0; i < 25; ++i) {
+    layer.insertEdge(i, i + 1);
+  }
+  expected_size += 25 * 116;  // 16258 bytes
+  EXPECT_EQ(layer.memoryUsage(), expected_size);
+}
+
+TEST(MemoryUsage, SceneGraph) {
+  SceneGraph graph;
+  size_t expected_size = 2409;
+  EXPECT_EQ(graph.memoryUsage(), expected_size);
+
+  // Add a layer.
+  graph.addLayer(1, 0, "test_layer");
+  expected_size += 458;  // Layer size.
+  EXPECT_EQ(graph.memoryUsage(), expected_size);
+
+  // Add a partitioned layer.
+  graph.addLayer(2, 1, "test_layer_partition");
+  expected_size += 120;  // Layer size.
+  EXPECT_EQ(graph.memoryUsage(), expected_size);
+
+  // Add some nodes.
+  for (size_t i = 0; i < 20; ++i) {
+    graph.emplaceNode(1, i, std::make_unique<NodeAttributes>(), 0);
+    graph.emplaceNode(2, 20 + i, std::make_unique<NodeAttributes>(), 1);
+  }
+  expected_size += 6140;
+  EXPECT_EQ(graph.memoryUsage(), expected_size);
+
+  // Add some intralayer edges.
+  for (size_t i = 0; i < 20; ++i) {
+    graph.insertEdge(i, (i + 1) % 20);
+    graph.insertEdge(20 + i, 20 + (i + 1) % 20);
+  }
+  expected_size += 40 * 58;
+  EXPECT_EQ(graph.memoryUsage(), expected_size);
+
+  // Add some interlayer edges.
+  for (size_t i = 0; i < 20; ++i) {
+    graph.insertEdge(i, 20 + i);
+  }
+  expected_size += 20 * 108;
+  EXPECT_EQ(graph.memoryUsage(), expected_size);
+
+  // Add mesh.
+  auto mesh = std::make_unique<Mesh>();
+  mesh->points.resize(1000);
+  mesh->colors.resize(1000);
+  graph.setMesh(std::move(mesh));
+  expected_size += 28160;  // Mesh size.
+  EXPECT_EQ(graph.memoryUsage(), expected_size);
+
+  // Add metadata.
+  nlohmann::json meta_contents;
+  meta_contents["creator"] = "unit_test";
+  meta_contents["description"] = "Test scene graph";
+  graph.metadata.set(meta_contents);
+  expected_size += 56;
+  EXPECT_EQ(graph.memoryUsage(), expected_size);
+}
+
+SceneGraph::Ptr populateSceneGraph(size_t size) {
+  auto graph = std::make_shared<SceneGraph>();
+  graph->addLayer(1, 0, "test_layer");
+  graph->addLayer(2, 1, "test_layer_partition");
+  auto attrs = std::make_unique<SemanticNodeAttributes>();
+  attrs->semantic_feature.resize(128, 64);
+  for (size_t i = 0; i < size; ++i) {
+    graph->emplaceNode(1, i, attrs->clone(), 0);
+    graph->emplaceNode(2, size + i, attrs->clone(), 1);
+  }
+  for (size_t i = 0; i < size; ++i) {
+    graph->insertEdge(i, (i + 1) % size);
+    graph->insertEdge(size + i, size + (i + 1) % size);
+  }
+  for (size_t i = 0; i < size; ++i) {
+    graph->insertEdge(i, size + i);
+  }
+  auto mesh = std::make_unique<Mesh>();
+  mesh->points.resize(10 * size);
+  mesh->colors.resize(10 * size);
+  graph->setMesh(std::move(mesh));
+  return graph;
+}
+
+TEST(MemoryUsage, SerializationComparison) {
+  for (const auto& size : {10, 100, 1000}) {
+    // Serialize to a byte stream and compare with estimated memory usage.
+    SCOPED_TRACE("Scene graph size: " + std::to_string(size));
+    std::cout << "Scene graph size: " << size << std::endl;
+    auto graph = populateSceneGraph(size);
+    std::vector<uint8_t> buffer;
+    io::binary::writeGraph(*graph, buffer, true);
+    const double ratio =
+        static_cast<double>(buffer.size()) / static_cast<double>(graph->memoryUsage());
+
+    EXPECT_LT(ratio, 2.0);
+    EXPECT_GT(ratio, 1.9);
+  }
+}
+
+}  // namespace spark_dsg::tests

--- a/tests/utest_memory_usage.cpp
+++ b/tests/utest_memory_usage.cpp
@@ -43,8 +43,6 @@
 #include <spark_dsg/scene_graph_node.h>
 #include <spark_dsg/serialization/graph_binary_serialization.h>
 
-#include "spark_dsg/logging.h"
-
 // TODO(lschmid): These tests are a quick sanity check and might break on different
 // platforms or with some future changes.
 
@@ -180,12 +178,12 @@ TEST(MemoryUsage, SceneGraph) {
 
   // Add a layer.
   graph.addLayer(1, 0, "test_layer");
-  expected_size += 458;  // Layer size.
+  expected_size += 458;
   EXPECT_EQ(graph.memoryUsage(), expected_size);
 
   // Add a partitioned layer.
   graph.addLayer(2, 1, "test_layer_partition");
-  expected_size += 120;  // Layer size.
+  expected_size += 120;
   EXPECT_EQ(graph.memoryUsage(), expected_size);
 
   // Add some nodes.
@@ -256,13 +254,11 @@ TEST(MemoryUsage, SerializationComparison) {
   for (const auto& size : {10, 100, 1000}) {
     // Serialize to a byte stream and compare with estimated memory usage.
     SCOPED_TRACE("Scene graph size: " + std::to_string(size));
-    std::cout << "Scene graph size: " << size << std::endl;
     auto graph = populateSceneGraph(size);
     std::vector<uint8_t> buffer;
     io::binary::writeGraph(*graph, buffer, true);
     const double ratio =
         static_cast<double>(buffer.size()) / static_cast<double>(graph->memoryUsage());
-
     EXPECT_LT(ratio, 2.0);
     EXPECT_GT(ratio, 1.9);
   }


### PR DESCRIPTION
- Adds estimation of memory usage of the DSG
- Estimation of attribute data usage is still a bit biased as it uses the serialization as proxy, might fix in the future if needed.
- Adds utest (mostly for sanity checking, it might be a bit brittle / system dependent).

@marcusabate This should expose all of the data / interfaces you need if you want to create more detailed memory analyses. You can look through the individual implementations if you want to see how the different memory is counted.