### PR TITLE
Feature/cleanup 2d places

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.22)
-project(spark_dsg VERSION 1.1.3)
+project(spark_dsg VERSION 1.1.4)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/include/spark_dsg/node_attributes.h
+++ b/include/spark_dsg/node_attributes.h
@@ -61,21 +61,20 @@ using NodeAttributeRegistration =
     serialization::AttributeRegistration<NodeAttributes, T>;
 
 #define REGISTER_NODE_ATTRIBUTES(attr_type)                                  \
-  inline static const auto registration_ =                                   \
+  inline static const auto attr_type##registration_ =                        \
       NodeAttributeRegistration<attr_type>(#attr_type);                      \
   const serialization::RegistrationInfo& registrationImpl() const override { \
-    return registration_.info;                                               \
+    return attr_type##registration_.info;                                    \
   }                                                                          \
   static_assert(true, "")
 
-// TODO(nathan) handle this better
 /**
- * @brief Typedef representing the semantic class of an object or other node
+ * @brief Type alias representing the semantic class of an object or other node
  */
 using SemanticLabel = uint32_t;
 
 /**
- * @brief Information related to place to mesh coorespondence
+ * @brief Information related to place to mesh correspondence
  */
 struct NearestVertexInfo {
   int32_t block[3];
@@ -110,11 +109,11 @@ struct NodeAttributes {
 
   //! Position of the node
   Eigen::Vector3d position;
-  //! last time the place was updated (while active)
+  //! Last time the place was updated (while active)
   uint64_t last_update_time_ns;
-  //! whether or not the node is in the active window
+  //! Whether or not the node is in the active window
   bool is_active;
-  //! whether the node was observed by Hydra, or added as a prediction
+  //! Whether the node was observed by Hydra, or added as a prediction
   bool is_predicted;
   //! Arbitrary node metadata
   Metadata metadata;
@@ -139,19 +138,16 @@ struct NodeAttributes {
   virtual size_t memoryUsage() const;
 
  protected:
-  //! actually output information to the std::ostream
   virtual std::ostream& fill_ostream(std::ostream& out) const;
-  //! dispatch function for serialization
   virtual void serialization_info();
-  //! dispatch function for serialization
   void serialization_info() const;
-  //! compute equality
   virtual bool is_equal(const NodeAttributes& other) const;
 
+ private:
   inline static const auto registration_ =
       NodeAttributeRegistration<NodeAttributes>("NodeAttributes");
 
-  //! get registration
+ protected:
   virtual const serialization::RegistrationInfo& registrationImpl() const {
     return registration_.info;
   }
@@ -163,12 +159,12 @@ struct NodeAttributes {
 struct SemanticNodeAttributes : public NodeAttributes {
  public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-  //! pointer type for node
+  //! Pointer type for node
   using Ptr = std::unique_ptr<SemanticNodeAttributes>;
 
-  //! alias for semantic label
+  //! Alias for semantic label
   using Label = SemanticLabel;
-  // !flag for whether or not semantic label should be considered valid
+  //! Flag for whether or not semantic label should be considered valid
   inline static constexpr Label NO_SEMANTIC_LABEL = std::numeric_limits<Label>::max();
 
   SemanticNodeAttributes();
@@ -217,11 +213,11 @@ struct ObjectNodeAttributes : public SemanticNodeAttributes {
   NodeAttributes::Ptr clone() const override;
   void transform(const Eigen::Isometry3d& transform) override;
 
-  //! Mesh vertice connections
+  //! Mesh vertex connections
   std::list<size_t> mesh_connections;
   //! Whether or not the object is known (and registered)
   bool registered;
-  //! rotation of object w.r.t. world (only valid when registerd)
+  //! Rotation of object with respect to world (only valid when registered)
   Eigen::Quaterniond world_R_object;
 
  protected:
@@ -260,9 +256,8 @@ struct RoomNodeAttributes : public SemanticNodeAttributes {
 
 /**
  * @brief Additional node attributes for a place
- * In addition to the normal semantic properties, a room has the minimum
- * distance to an obstacle and the number of basis points for that vertex in the
- * GVD
+ * In addition to the normal semantic properties, a place has the minimum
+ * distance to an obstacle and the number of basis points for that vertex
  */
 struct PlaceNodeAttributes : public SemanticNodeAttributes {
  public:
@@ -274,7 +269,7 @@ struct PlaceNodeAttributes : public SemanticNodeAttributes {
 
   /**
    * @brief make places node attributes
-   * @param distance distance to nearest obstalce
+   * @param distance distance to nearest obstacle
    * @param num_basis_points number of basis points of the places node
    */
   PlaceNodeAttributes(double distance, unsigned int num_basis_points);
@@ -285,13 +280,13 @@ struct PlaceNodeAttributes : public SemanticNodeAttributes {
   double distance;
   //! number of equidistant obstacles
   unsigned int num_basis_points;
-  //! voxblox mesh vertices that are closest to this place
+  //! Mesh vertices that are closest to this place
   std::vector<NearestVertexInfo> voxblox_mesh_connections;
-  //! pcl mesh vertices that are closest to this place
+  //! Mesh vertices that are closest to this place
   std::vector<size_t> pcl_mesh_connections;
   //! semantic labels of parents
   std::vector<uint8_t> mesh_vertex_labels;
-  //! deformation vertices that are closest to this place
+  //! Deformation vertices that are closest to this place
   std::vector<size_t> deformation_connections;
 
   bool real_place = true;
@@ -325,25 +320,25 @@ struct Place2dNodeAttributes : public SemanticNodeAttributes {
   virtual ~Place2dNodeAttributes() = default;
   NodeAttributes::Ptr clone() const override;
 
-  //! mesh vertices that are closest to this place
+  //! Mesh vertices that are closest to this place
   std::list<size_t> mesh_connections;
-  //! mesh vertices corresponding to boundary points
+  //! Mesh vertices corresponding to boundary points
   std::vector<size_t> boundary_connections;
-  //! points on boundary of place region
+  //! Points on boundary of place region
   std::vector<Eigen::Vector3d> boundary;
-  //! center of intersection checking ellipsoid
+  //! Center of intersection checking ellipsoid
   Eigen::Vector3d ellipse_centroid;
-  //! shape matrix for intersection checking ellipsoid
+  //! Shape matrix for intersection checking ellipsoid
   Eigen::Matrix<double, 2, 2> ellipse_matrix_compress;
-  //! shape matrix for plotting ellipsoid
+  //! Shape matrix for plotting ellipsoid
   Eigen::Matrix<double, 2, 2> ellipse_matrix_expand;
-  //! min vertex index of associated mesh vertices
+  //! Minimum vertex index of associated mesh vertices
   size_t min_mesh_index;
-  //! max vertex index of associated mesh vertices
+  //! Max vertex index of associated mesh vertices
   size_t max_mesh_index;
-  //! tracks whether the node still needs to be cleaned up during merging
+  //! Tracks whether the node still needs to be cleaned up during merging
   bool need_finish_merge;
-  //! whether this node has mesh vertices in active window
+  //! Whether this node has mesh vertices in active window
   bool has_active_mesh_indices;
 
  protected:

--- a/include/spark_dsg/node_attributes.h
+++ b/include/spark_dsg/node_attributes.h
@@ -326,7 +326,7 @@ struct Place2dNodeAttributes : public SemanticNodeAttributes {
   NodeAttributes::Ptr clone() const override;
 
   //! mesh vertices that are closest to this place
-  std::vector<size_t> mesh_connections;
+  std::list<size_t> mesh_connections;
   //! mesh vertices corresponding to boundary points
   std::vector<size_t> boundary_connections;
   //! points on boundary of place region

--- a/include/spark_dsg/node_attributes.h
+++ b/include/spark_dsg/node_attributes.h
@@ -322,15 +322,13 @@ struct Place2dNodeAttributes : public SemanticNodeAttributes {
   using Ptr = std::unique_ptr<Place2dNodeAttributes>;
 
   Place2dNodeAttributes();
-
-  /**
-   * @brief make places node attributes
-   * @param boundary Boundary points surrounding place
-   */
-  Place2dNodeAttributes(std::vector<Eigen::Vector3d> boundary);
   virtual ~Place2dNodeAttributes() = default;
   NodeAttributes::Ptr clone() const override;
 
+  //! mesh vertices that are closest to this place
+  std::vector<size_t> mesh_connections;
+  //! mesh vertices corresponding to boundary points
+  std::vector<size_t> boundary_connections;
   //! points on boundary of place region
   std::vector<Eigen::Vector3d> boundary;
   //! center of intersection checking ellipsoid
@@ -339,24 +337,12 @@ struct Place2dNodeAttributes : public SemanticNodeAttributes {
   Eigen::Matrix<double, 2, 2> ellipse_matrix_compress;
   //! shape matrix for plotting ellipsoid
   Eigen::Matrix<double, 2, 2> ellipse_matrix_expand;
-  //! pcl mesh vertices corresponding to boundary points
-  std::vector<size_t> pcl_boundary_connections;
-  //! voxblox mesh vertices that are closest to this place
-  std::vector<NearestVertexInfo> voxblox_mesh_connections;
-  //! pcl mesh vertices that are closest to this place
-  std::vector<size_t> pcl_mesh_connections;
   //! min vertex index of associated mesh vertices
-  size_t pcl_min_index;
+  size_t min_mesh_index;
   //! max vertex index of associated mesh vertices
-  size_t pcl_max_index;
-  //! semantic labels of parents
-  std::vector<uint8_t> mesh_vertex_labels;
-  //! deformation vertices that are closest to this place
-  std::vector<size_t> deformation_connections;
+  size_t max_mesh_index;
   //! tracks whether the node still needs to be cleaned up during merging
   bool need_finish_merge;
-  //! whether this node has been merged to while in current active window
-  bool need_cleanup_splitting;
   //! whether this node has mesh vertices in active window
   bool has_active_mesh_indices;
 

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>spark_dsg</name>
-  <version>1.1.3</version>
+  <version>1.1.4</version>
   <description>3D Scene Graph (3DSG) type definitions and core library code</description>
 
   <author email="na26933@mit.edu">Nathan Hughes</author>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "spark_dsg"
-version = "1.1.3"
+version = "1.1.4"
 description = "Library for representing 3D scene graphs"
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/python/bindings/src/attributes.cpp
+++ b/python/bindings/src/attributes.cpp
@@ -41,9 +41,6 @@
 #include <spark_dsg/mesh.h>
 #include <spark_dsg/node_attributes.h>
 
-#include <filesystem>
-
-#include "spark_dsg/python/mesh.h"
 #include "spark_dsg/python/python_types.h"
 
 namespace spark_dsg::python {
@@ -171,15 +168,16 @@ void init_attributes(py::module_& m) {
 
   py::class_<Place2dNodeAttributes, SemanticNodeAttributes>(m, "Place2dNodeAttributes")
       .def(py::init<>())
+      .def_readwrite("mesh_connections", &Place2dNodeAttributes::mesh_connections)
+      .def_readwrite("boundary_connections", &Place2dNodeAttributes::boundary_connections)
       .def_readwrite("boundary", &Place2dNodeAttributes::boundary)
+      .def_readwrite("ellipse_centroid", &Place2dNodeAttributes::ellipse_centroid)
       .def_readwrite("ellipse_matrix_compress", &Place2dNodeAttributes::ellipse_matrix_compress)
       .def_readwrite("ellipse_matrix_expand", &Place2dNodeAttributes::ellipse_matrix_expand)
-      .def_readwrite("ellipse_centroid", &Place2dNodeAttributes::ellipse_centroid)
-      .def_readwrite("pcl_boundary_connections", &Place2dNodeAttributes::pcl_boundary_connections)
-      .def_readwrite("voxblox_mesh_connections", &Place2dNodeAttributes::voxblox_mesh_connections)
-      .def_readwrite("pcl_mesh_connections", &Place2dNodeAttributes::pcl_mesh_connections)
-      .def_readwrite("mesh_vertex_labels", &Place2dNodeAttributes::mesh_vertex_labels)
-      .def_readwrite("deformation_connections", &Place2dNodeAttributes::deformation_connections);
+      .def_readwrite("min_mesh_index", &Place2dNodeAttributes::min_mesh_index)
+      .def_readwrite("max_mesh_index", &Place2dNodeAttributes::max_mesh_index)
+      .def_readwrite("need_finish_merge", &Place2dNodeAttributes::need_finish_merge)
+      .def_readwrite("has_active_mesh_indices", &Place2dNodeAttributes::has_active_mesh_indices);
 
   py::class_<BoundaryInfo>(m, "BoundaryInfo")
       .def(py::init<>())


### PR DESCRIPTION
Removes old unused 2D place attributes inherited from the 3D places and renames some of the fields to drop the `pcl` prefix. Other change is that I swapped the mesh connections to be a list instead of a vector for in-place removals (which happen a lot). There's some corresponding changes to Hydra that I'm hoping to PR later today