### PR TITLE
parse version from package.xml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 3.22)
-project(spark_dsg VERSION 1.1.4)
 
+file(READ ${CMAKE_CURRENT_SOURCE_DIR}/package.xml PACKAGE_XML)
+string(REGEX MATCH "<version>(.+)</version>" VERSION_MATCH ${PACKAGE_XML})
+if ("${CMAKE_MATCH_0}" STREQUAL "")
+    message(FATAL_ERROR "Could not parse version from package.xml")
+endif()
+
+project(spark_dsg VERSION ${CMAKE_MATCH_1})
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "spark_dsg"
-version = "1.1.4"
+dynamic = ["version"]
 description = "Library for representing 3D scene graphs"
 readme = "README.md"
 license = "BSD-3-Clause"
@@ -35,6 +35,11 @@ Repository = "https://github.com/MIT-SPARK/Spark-DSG"
 
 [project.scripts]
 spark-dsg = "spark_dsg.__main__:cli"
+
+[tool.scikit-build.metadata.version]
+provider = "scikit_build_core.metadata.regex"
+input = "package.xml"
+regex = "<version>(?P<value>.+)</version>"
 
 [tool.scikit-build.cmake.define]
 SPARK_DSG_BUILD_PYTHON = "ON"


### PR DESCRIPTION
Makes the python bindings and cmake pull the package version directly from `package.xml` so we don't have to set it in three places every time we increment it