### PR TITLE
Fix/pybind11 update

### DIFF
--- a/include/spark_dsg/scene_graph.h
+++ b/include/spark_dsg/scene_graph.h
@@ -455,6 +455,9 @@ class SceneGraph {
   //! @brief Make a copy of the scene graph
   SceneGraph::Ptr clone() const;
 
+  //! @brief Make a copy of the scene graph (for bindings)
+  std::unique_ptr<SceneGraph> clone_unique() const;
+
   //! @brief Rigidly transform graph
   void transform(const Eigen::Isometry3d& transform);
 
@@ -488,7 +491,7 @@ class SceneGraph {
   //! Any extra information about the graph
   Metadata metadata;
 
-  SceneGraph::Ptr create_subgraph(const std::vector<NodeId>& nodes);
+  std::unique_ptr<SceneGraph> create_subgraph(const std::vector<NodeId>& nodes);
 
  protected:
   Layer& layerFromKey(const LayerKey& key);

--- a/include/spark_dsg/serialization/file_io.h
+++ b/include/spark_dsg/serialization/file_io.h
@@ -63,7 +63,7 @@ FileType identifyFileType(const std::filesystem::path& filepath);
  * @throws std::runtime_error if the extension is invalid.
  * @return The file type of the resulting filepath.
  */
-FileType verifyFileExtension(std::filesystem::path& filepath);
+FileType verifyFileExtension(const std::filesystem::path& filepath);
 
 /**
  * @brief Save a SceneGraph to a JSON file.
@@ -80,7 +80,7 @@ void saveDsgJson(const SceneGraph& graph,
  * @param filepath The filepath including extension to load from.
  * @return A pointer to the loaded graph or nullptr if loading failed.
  */
-std::shared_ptr<SceneGraph> loadDsgJson(const std::filesystem::path& filepath);
+std::unique_ptr<SceneGraph> loadDsgJson(const std::filesystem::path& filepath);
 
 /**
  * @brief Save a SceneGraph to a file in binary serialization.
@@ -97,6 +97,13 @@ void saveDsgBinary(const SceneGraph& graph,
  * @param filepath The filepath including extension to load from.
  * @return A pointer to the loaded graph or nullptr if loading failed.
  */
-std::shared_ptr<SceneGraph> loadDsgBinary(const std::filesystem::path& filepath);
+std::unique_ptr<SceneGraph> loadDsgBinary(const std::filesystem::path& filepath);
+
+/**
+ * @brief Load a SceneGraph from a provided filepath
+ * @param filepath The filepath including extension to load from.
+ * @return A pointer to the loaded graph or nullptr if loading failed.
+ */
+std::unique_ptr<SceneGraph> loadDsgFromFile(const std::filesystem::path& filepath);
 
 }  // namespace spark_dsg::io

--- a/include/spark_dsg/serialization/file_io.h
+++ b/include/spark_dsg/serialization/file_io.h
@@ -63,7 +63,7 @@ FileType identifyFileType(const std::filesystem::path& filepath);
  * @throws std::runtime_error if the extension is invalid.
  * @return The file type of the resulting filepath.
  */
-FileType verifyFileExtension(const std::filesystem::path& filepath);
+FileType verifyFileExtension(std::filesystem::path& filepath);
 
 /**
  * @brief Save a SceneGraph to a JSON file.
@@ -102,7 +102,6 @@ std::unique_ptr<SceneGraph> loadDsgBinary(const std::filesystem::path& filepath)
 /**
  * @brief Load a SceneGraph from a provided filepath
  * @param filepath The filepath including extension to load from.
- * @return A pointer to the loaded graph or nullptr if loading failed.
  */
 std::unique_ptr<SceneGraph> loadDsgFromFile(const std::filesystem::path& filepath);
 

--- a/include/spark_dsg/serialization/graph_binary_serialization.h
+++ b/include/spark_dsg/serialization/graph_binary_serialization.h
@@ -45,22 +45,16 @@ void writeGraph(const SceneGraph& graph,
 
 void writeLayer(const SceneGraphLayer& graph, std::vector<uint8_t>& buffer);
 
-std::shared_ptr<SceneGraph> readGraph(const uint8_t* const buffer, size_t length);
+std::unique_ptr<SceneGraph> readGraph(const uint8_t* const buffer, size_t length);
 
-inline std::shared_ptr<SceneGraph> readGraph(const std::vector<uint8_t>& buffer) {
-  return readGraph(buffer.data(), buffer.size());
-}
+std::unique_ptr<SceneGraph> readGraph(const std::vector<uint8_t>& buffer);
 
-std::shared_ptr<SceneGraphLayer> readLayer(const uint8_t* const buffer, size_t length);
+std::unique_ptr<SceneGraphLayer> readLayer(const uint8_t* const buffer, size_t length);
 
-inline std::shared_ptr<SceneGraphLayer> readLayer(const std::vector<uint8_t>& buffer) {
-  return readLayer(buffer.data(), buffer.size());
-}
+std::unique_ptr<SceneGraphLayer> readLayer(const std::vector<uint8_t>& buffer);
 
 bool updateGraph(SceneGraph& graph, const uint8_t* const buffer, size_t length);
 
-inline bool updateGraph(SceneGraph& graph, const std::vector<uint8_t>& buffer) {
-  return updateGraph(graph, buffer.data(), buffer.size());
-}
+bool updateGraph(SceneGraph& graph, const std::vector<uint8_t>& buffer);
 
 }  // namespace spark_dsg::io::binary

--- a/include/spark_dsg/serialization/graph_json_serialization.h
+++ b/include/spark_dsg/serialization/graph_json_serialization.h
@@ -51,6 +51,6 @@ std::string writeGraph(const SceneGraph& graph, bool include_mesh = false);
  * @param contents JSON string to parse
  * @returns Resulting parsed scene graph
  */
-std::shared_ptr<SceneGraph> readGraph(const std::string& contents);
+std::unique_ptr<SceneGraph> readGraph(const std::string& contents);
 
 }  // namespace spark_dsg::io::json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core", "pybind11<3"]
+requires = ["scikit-build-core", "pybind11"]
 build-backend = "scikit_build_core.build"
 
 [project]

--- a/python/bindings/src/scene_graph.cpp
+++ b/python/bindings/src/scene_graph.cpp
@@ -63,7 +63,7 @@ void init_scene_graph(py::module_& m) {
         "depth"_a = 1,
         "bbox_type"_a = BoundingBox::Type::AABB);
 
-  py::class_<SceneGraph, std::shared_ptr<SceneGraph>>(m, "SceneGraph", py::dynamic_attr())
+  py::class_<SceneGraph>(m, "SceneGraph", py::dynamic_attr())
       .def(py::init<bool>(), "empty"_a = false)
       .def(py::init<const SceneGraph::LayerKeys&, const SceneGraph::LayerNames&>(),
            "layer_keys"_a,

--- a/python/bindings/src/scene_graph.cpp
+++ b/python/bindings/src/scene_graph.cpp
@@ -43,11 +43,8 @@
 #include <spark_dsg/node_attributes.h>
 #include <spark_dsg/scene_graph.h>
 #include <spark_dsg/scene_graph_utilities.h>
+#include <spark_dsg/serialization/file_io.h>
 #include <spark_dsg/serialization/graph_binary_serialization.h>
-
-#include <filesystem>
-#include <iomanip>
-#include <sstream>
 
 #include "spark_dsg/python/python_layer_view.h"
 #include "spark_dsg/python/python_types.h"
@@ -216,8 +213,8 @@ void init_scene_graph(py::module_& m) {
           "filepath"_a,
           "include_mesh"_a = true)
       .def("create_subgraph", &SceneGraph::create_subgraph)
-      .def_static("load", &SceneGraph::load)
-      .def_static("load", [](const std::string& filepath) { return SceneGraph::load(filepath); })
+      .def_static("load", [](const std::filesystem::path& filepath) { return io::loadDsgFromFile(filepath); })
+      .def_static("load", [](const std::string& filepath) { return io::loadDsgFromFile(filepath); })
       .def_readwrite("_metadata", &SceneGraph::metadata)
       .def_property_readonly("layer_ids", &SceneGraph::layer_ids)
       .def_property_readonly("layer_keys", &SceneGraph::layer_keys)
@@ -265,13 +262,13 @@ void init_scene_graph(py::module_& m) {
           [](const SceneGraph& graph) { return graph.mesh(); },
           [](SceneGraph& graph, const Mesh::Ptr& mesh) { graph.setMesh(mesh); })
       .def("get_layer_key", &SceneGraph::getLayerKey, "name"_a)
-      .def("clone", &SceneGraph::clone)
+      .def("clone", &SceneGraph::clone_unique)
       .def("transform",
            [](SceneGraph& G, const Eigen::Matrix4d& mat) {
              Eigen::Isometry3d iso(mat);
              G.transform(iso);
            })
-      .def("__deepcopy__", [](const SceneGraph& G, py::object) { return G.clone(); })
+      .def("__deepcopy__", [](const SceneGraph& G, py::object) { return G.clone_unique(); })
       .def(
           "to_binary",
           [](const SceneGraph& graph, bool include_mesh) {

--- a/python/bindings/src/scene_graph_layer.cpp
+++ b/python/bindings/src/scene_graph_layer.cpp
@@ -54,7 +54,7 @@ namespace py = pybind11;
 using namespace py::literals;
 
 void init_scene_graph_layer(py::module_& m) {
-  py::class_<SceneGraphLayer, std::shared_ptr<SceneGraphLayer>>(m, "SceneGraphLayer")
+  py::class_<SceneGraphLayer>(m, "SceneGraphLayer")
       .def(py::init<LayerId>())
       .def(py::init<const std::string&>())
       .def("add_node",

--- a/src/scene_graph.cpp
+++ b/src/scene_graph.cpp
@@ -50,6 +50,7 @@ using Edge = SceneGraphEdge;
 using Layer = SceneGraphLayer;
 using LayerCallback = std::function<void(LayerKey, Layer&)>;
 using ConstLayerCallback = std::function<void(LayerKey, const Layer&)>;
+using UniqueGraph = std::unique_ptr<SceneGraph>;
 
 using Partitions = SceneGraph::Partitions;
 using LayerNames = SceneGraph::LayerNames;
@@ -670,8 +671,10 @@ void SceneGraph::removeAllStaleEdges() {
   removeStaleEdges(interlayer_edges_);
 }
 
-SceneGraph::Ptr SceneGraph::clone() const {
-  auto to_return = std::make_shared<SceneGraph>(layer_keys(), layer_names_);
+SceneGraph::Ptr SceneGraph::clone() const { return clone_unique(); }
+
+UniqueGraph SceneGraph::clone_unique() const {
+  auto to_return = std::make_unique<SceneGraph>(layer_keys(), layer_names_);
   to_return->metadata = metadata;
 
   for (const auto [node_id, key] : node_lookup_) {
@@ -724,17 +727,7 @@ void SceneGraph::save(std::filesystem::path filepath, bool include_mesh) const {
 }
 
 SceneGraph::Ptr SceneGraph::load(std::filesystem::path filepath) {
-  if (!std::filesystem::exists(filepath)) {
-    throw std::runtime_error("graph file does not exist: " + filepath.string());
-  }
-
-  const auto type = io::verifyFileExtension(filepath);
-  if (type == io::FileType::JSON) {
-    return io::loadDsgJson(filepath);
-  }
-
-  // Can only be binary after verification (worstcase: throws meaningful error)
-  return io::loadDsgBinary(filepath);
+  return io::loadDsgFromFile(filepath);
 }
 
 void SceneGraph::setMesh(const std::shared_ptr<Mesh>& mesh) { mesh_ = mesh; }
@@ -970,8 +963,8 @@ std::vector<LayerId> SceneGraph::layer_ids() const {
   return std::vector<LayerId>(layers.begin(), layers.end());
 }
 
-SceneGraph::Ptr SceneGraph::create_subgraph(const std::vector<NodeId>& nodes) {
-  auto graph = std::make_shared<SceneGraph>();
+UniqueGraph SceneGraph::create_subgraph(const std::vector<NodeId>& nodes) {
+  auto graph = std::make_unique<SceneGraph>();
 
   for (auto& [string, layerkey] : layer_names_) {
     graph->addLayer(layerkey.layer, layerkey.partition, string);

--- a/src/serialization/file_io.cpp
+++ b/src/serialization/file_io.cpp
@@ -38,6 +38,7 @@
 #include <fstream>
 #include <sstream>
 
+#include "spark_dsg/scene_graph.h"
 #include "spark_dsg/serialization/graph_binary_serialization.h"
 #include "spark_dsg/serialization/graph_json_serialization.h"
 #include "spark_dsg/serialization/versioning.h"
@@ -56,13 +57,12 @@ FileType identifyFileType(const std::filesystem::path& filepath) {
   return FileType::UNKNOWN;
 }
 
-FileType verifyFileExtension(std::filesystem::path& filepath) {
+FileType verifyFileExtension(const std::filesystem::path& filepath) {
   io::FileType type = io::identifyFileType(filepath);
 
   // If no file extension is provided, default to binary.
   if (type == io::FileType::NONE) {
     type = io::FileType::BINARY;
-    filepath += io::BINARY_EXTENSION;
   }
 
   // Check the file extension is valid.
@@ -94,7 +94,7 @@ void saveDsgBinary(const SceneGraph& graph,
   out.write(reinterpret_cast<const char*>(graph_buffer.data()), graph_buffer.size());
 }
 
-std::shared_ptr<SceneGraph> loadDsgBinary(const std::filesystem::path& filepath) {
+std::unique_ptr<SceneGraph> loadDsgBinary(const std::filesystem::path& filepath) {
   // Read the file into a buffer.
   std::ifstream infile(filepath, std::ios::in | std::ios::binary);
   std::vector<uint8_t> buffer((std::istreambuf_iterator<char>(infile)),
@@ -120,11 +120,25 @@ void saveDsgJson(const SceneGraph& graph,
   outfile << json::writeGraph(graph, include_mesh);
 }
 
-std::shared_ptr<SceneGraph> loadDsgJson(const std::filesystem::path& filepath) {
+std::unique_ptr<SceneGraph> loadDsgJson(const std::filesystem::path& filepath) {
   std::ifstream infile(filepath);
   std::stringstream ss;
   ss << infile.rdbuf();
   return json::readGraph(ss.str());
+}
+
+std::unique_ptr<SceneGraph> loadDsgFromFile(const std::filesystem::path& filepath) {
+  if (!std::filesystem::exists(filepath)) {
+    throw std::runtime_error("graph file does not exist: " + filepath.string());
+  }
+
+  const auto type = verifyFileExtension(filepath);
+  if (type == FileType::JSON) {
+    return loadDsgJson(filepath);
+  }
+
+  // Can only be binary after verification (worstcase: throws meaningful error)
+  return loadDsgBinary(filepath);
 }
 
 }  // namespace spark_dsg::io

--- a/src/serialization/file_io.cpp
+++ b/src/serialization/file_io.cpp
@@ -57,12 +57,13 @@ FileType identifyFileType(const std::filesystem::path& filepath) {
   return FileType::UNKNOWN;
 }
 
-FileType verifyFileExtension(const std::filesystem::path& filepath) {
+FileType verifyFileExtension(std::filesystem::path& filepath) {
   io::FileType type = io::identifyFileType(filepath);
 
   // If no file extension is provided, default to binary.
   if (type == io::FileType::NONE) {
     type = io::FileType::BINARY;
+    filepath += io::BINARY_EXTENSION;
   }
 
   // Check the file extension is valid.
@@ -132,7 +133,8 @@ std::unique_ptr<SceneGraph> loadDsgFromFile(const std::filesystem::path& filepat
     throw std::runtime_error("graph file does not exist: " + filepath.string());
   }
 
-  const auto type = verifyFileExtension(filepath);
+  auto path_for_verification = filepath;
+  const auto type = verifyFileExtension(path_for_verification);
   if (type == FileType::JSON) {
     return loadDsgJson(filepath);
   }

--- a/src/serialization/graph_binary_serialization.cpp
+++ b/src/serialization/graph_binary_serialization.cpp
@@ -341,11 +341,11 @@ bool updateGraph(SceneGraph& graph, const BinaryDeserializer& deserializer) {
   return true;
 }
 
-SceneGraph::Ptr readGraph(const uint8_t* const buffer, size_t length) {
+std::unique_ptr<SceneGraph> readGraph(const uint8_t* const buffer, size_t length) {
   BinaryDeserializer deserializer(buffer, length);
 
   // make an empty graph
-  auto graph = std::make_shared<SceneGraph>(true);
+  auto graph = std::make_unique<SceneGraph>(true);
   if (!updateGraph(*graph, deserializer)) {
     return nullptr;
   }
@@ -353,14 +353,18 @@ SceneGraph::Ptr readGraph(const uint8_t* const buffer, size_t length) {
   return graph;
 }
 
-std::shared_ptr<SceneGraphLayer> readLayer(const uint8_t* const buffer, size_t length) {
+std::unique_ptr<SceneGraph> readGraph(const std::vector<uint8_t>& buffer) {
+  return readGraph(buffer.data(), buffer.size());
+}
+
+std::unique_ptr<SceneGraphLayer> readLayer(const uint8_t* const buffer, size_t length) {
   const auto& header = io::GlobalInfo::loadedHeader();
 
   BinaryDeserializer deserializer(buffer, length);
   LayerId layer_id;
   deserializer.read(layer_id);
 
-  auto graph = std::make_shared<SceneGraphLayer>(layer_id);
+  auto graph = std::make_unique<SceneGraphLayer>(layer_id);
 
   // load name to type index mapping if present
   const auto node_factory = loadFactory<NodeAttributes>(header, deserializer);
@@ -387,9 +391,17 @@ std::shared_ptr<SceneGraphLayer> readLayer(const uint8_t* const buffer, size_t l
   return graph;
 }
 
+std::unique_ptr<SceneGraphLayer> readLayer(const std::vector<uint8_t>& buffer) {
+  return readLayer(buffer.data(), buffer.size());
+}
+
 bool updateGraph(SceneGraph& graph, const uint8_t* const buffer, size_t length) {
   BinaryDeserializer deserializer(buffer, length);
   return updateGraph(graph, deserializer);
+}
+
+bool updateGraph(SceneGraph& graph, const std::vector<uint8_t>& buffer) {
+  return updateGraph(graph, buffer.data(), buffer.size());
 }
 
 }  // namespace io::binary

--- a/src/serialization/graph_json_serialization.cpp
+++ b/src/serialization/graph_json_serialization.cpp
@@ -155,7 +155,7 @@ std::string writeGraph(const SceneGraph& graph, bool include_mesh) {
   return record.dump();
 }
 
-SceneGraph::Ptr readGraph(const std::string& contents) {
+std::unique_ptr<SceneGraph> readGraph(const std::string& contents) {
   const auto record = nlohmann::json::parse(contents);
 
   // Parse header.
@@ -195,7 +195,7 @@ SceneGraph::Ptr readGraph(const std::string& contents) {
     layer_names = record.at("layer_names").get<SceneGraph::LayerNames>();
   }
 
-  auto graph = std::make_shared<SceneGraph>(layer_keys, layer_names);
+  auto graph = std::make_unique<SceneGraph>(layer_keys, layer_names);
 
   if (record.contains("metadata")) {
     graph->metadata = record["metadata"];


### PR DESCRIPTION
Changes most functions to return unique pointers instead of shared pointers to avoid bug with typecasters in pybind11 version 3.0.3