### PR TITLE
fix and test subgraph not returning metadata

### DIFF
--- a/src/scene_graph.cpp
+++ b/src/scene_graph.cpp
@@ -964,8 +964,8 @@ std::vector<LayerId> SceneGraph::layer_ids() const {
 }
 
 UniqueGraph SceneGraph::create_subgraph(const std::vector<NodeId>& nodes) {
-  auto to_return = std::make_unique<SceneGraph>(layer_keys(), layer_names_);
-  to_return->metadata = metadata;
+  auto graph = std::make_unique<SceneGraph>(layer_keys(), layer_names_);
+  graph->metadata = metadata;
 
   for (const auto& node_id : nodes) {
     const auto node = findNode(node_id);

--- a/src/scene_graph.cpp
+++ b/src/scene_graph.cpp
@@ -964,11 +964,8 @@ std::vector<LayerId> SceneGraph::layer_ids() const {
 }
 
 UniqueGraph SceneGraph::create_subgraph(const std::vector<NodeId>& nodes) {
-  auto graph = std::make_unique<SceneGraph>();
-
-  for (auto& [string, layerkey] : layer_names_) {
-    graph->addLayer(layerkey.layer, layerkey.partition, string);
-  }
+  auto to_return = std::make_unique<SceneGraph>(layer_keys(), layer_names_);
+  to_return->metadata = metadata;
 
   for (const auto& node_id : nodes) {
     const auto node = findNode(node_id);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,7 +8,6 @@ add_executable(
   utest_bounding_box_extraction.cpp
   utest_bounding_box.cpp
   utest_color.cpp
-  utest_dynamic_scene_graph.cpp
   utest_edge_container.cpp
   utest_graph_utilities_layer.cpp
   utest_labelspace.cpp
@@ -17,6 +16,7 @@ add_executable(
   utest_metadata.cpp
   utest_node_attributes.cpp
   utest_node_symbol.cpp
+  utest_scene_graph.cpp
   utest_scene_graph_layer.cpp
   utest_scene_graph_node.cpp
   utest_scene_graph_utilities.cpp

--- a/tests/utest_scene_graph.cpp
+++ b/tests/utest_scene_graph.cpp
@@ -937,7 +937,7 @@ TEST(SceneGraph, cloneCorrect) {
 TEST(SceneGraph, subgraphCorrect) {
   SceneGraph graph;
   graph.metadata.add(R"({"foo": 5, "bar": {"hello": 5, "world": 10}})"_json);
-  graph.graph.emplaceNode(2, "a0"_id, std::make_unique<NodeAttributes>(), 'a');
+  graph.emplaceNode(2, "a0"_id, std::make_unique<NodeAttributes>(), 'a');
   graph.emplaceNode(2, "a1"_id, std::make_unique<NodeAttributes>(), 'a');
   graph.emplaceNode(3, "x0"_id, std::make_unique<NodeAttributes>());
   graph.emplaceNode(3, "x1"_id, std::make_unique<NodeAttributes>());
@@ -956,15 +956,15 @@ TEST(SceneGraph, subgraphCorrect) {
 
   EXPECT_LT(subgraph->numNodes(), graph.numNodes());
   EXPECT_LT(subgraph->numEdges(), graph.numEdges());
-  EXPECT_TRUE(subraph->hasNode("a0"_id));
-  EXPECT_TRUE(subraph->hasNode("a1"_id));
-  EXPECT_TRUE(subraph->hasNode("x0"_id));
-  EXPECT_FALSE(subraph->hasNode("x1"_id));
-  EXPECT_TRUE(subraph->hasNode("y1"_id));
-  EXPECT_FALSE(subraph->hasEdge("x0"_id, "x1"_id));
-  EXPECT_TRUE(subraph->hasEdge("x0"_id, "y1"_id));
-  EXPECT_TRUE(subraph->hasEdge("a1"_id, "x0"_id));
-  EXPECT_TRUE(subraph->hasEdge("a0"_id, "a1"_id));
+  EXPECT_TRUE(subgraph->hasNode("a0"_id));
+  EXPECT_TRUE(subgraph->hasNode("a1"_id));
+  EXPECT_TRUE(subgraph->hasNode("x0"_id));
+  EXPECT_FALSE(subgraph->hasNode("x1"_id));
+  EXPECT_TRUE(subgraph->hasNode("y1"_id));
+  EXPECT_FALSE(subgraph->hasEdge("x0"_id, "x1"_id));
+  EXPECT_TRUE(subgraph->hasEdge("x0"_id, "y1"_id));
+  EXPECT_TRUE(subgraph->hasEdge("a1"_id, "x0"_id));
+  EXPECT_TRUE(subgraph->hasEdge("a0"_id, "a1"_id));
 }
 
 }  // namespace spark_dsg

--- a/tests/utest_scene_graph.cpp
+++ b/tests/utest_scene_graph.cpp
@@ -934,4 +934,37 @@ TEST(SceneGraph, cloneCorrect) {
   EXPECT_TRUE(clone->hasEdge("a0"_id, "a1"_id));
 }
 
+TEST(SceneGraph, subgraphCorrect) {
+  SceneGraph graph;
+  graph.metadata.add(R"({"foo": 5, "bar": {"hello": 5, "world": 10}})"_json);
+  graph.graph.emplaceNode(2, "a0"_id, std::make_unique<NodeAttributes>(), 'a');
+  graph.emplaceNode(2, "a1"_id, std::make_unique<NodeAttributes>(), 'a');
+  graph.emplaceNode(3, "x0"_id, std::make_unique<NodeAttributes>());
+  graph.emplaceNode(3, "x1"_id, std::make_unique<NodeAttributes>());
+  graph.emplaceNode(4, "y1"_id, std::make_unique<NodeAttributes>());
+  graph.insertEdge("x0"_id, "x1"_id);
+  graph.insertEdge("x0"_id, "y1"_id);
+  graph.insertEdge("a1"_id, "x0"_id);
+  graph.insertEdge("a0"_id, "a1"_id);
+
+  auto subgraph = graph.create_subgraph({"a0"_id, "a1"_id, "x0"_id, "y1"_id});
+  ASSERT_TRUE(subgraph != nullptr);
+  EXPECT_EQ(subgraph->metadata.get().dump(), graph.metadata.get().dump());
+  EXPECT_EQ(subgraph->layer_ids(), graph.layer_ids());
+  EXPECT_EQ(subgraph->layer_keys(), graph.layer_keys());
+  EXPECT_EQ(subgraph->layer_names(), graph.layer_names());
+
+  EXPECT_LT(subgraph->numNodes(), graph.numNodes());
+  EXPECT_LT(subgraph->numEdges(), graph.numEdges());
+  EXPECT_TRUE(subraph->hasNode("a0"_id));
+  EXPECT_TRUE(subraph->hasNode("a1"_id));
+  EXPECT_TRUE(subraph->hasNode("x0"_id));
+  EXPECT_FALSE(subraph->hasNode("x1"_id));
+  EXPECT_TRUE(subraph->hasNode("y1"_id));
+  EXPECT_FALSE(subraph->hasEdge("x0"_id, "x1"_id));
+  EXPECT_TRUE(subraph->hasEdge("x0"_id, "y1"_id));
+  EXPECT_TRUE(subraph->hasEdge("a1"_id, "x0"_id));
+  EXPECT_TRUE(subraph->hasEdge("a0"_id, "a1"_id));
+}
+
 }  // namespace spark_dsg


### PR DESCRIPTION
Fixes issues with labelspaces not sticking around when using `create_subgraph`