### PR TITLE
Adds Chesapeake color palette

### DIFF
--- a/include/spark_dsg/colormaps.h
+++ b/include/spark_dsg/colormaps.h
@@ -137,7 +137,13 @@ Color colorbrewerId(size_t id);
 Color distinct150Id(size_t id);
 
 /**
- * @brief Get the underlying color palette for the distinct150 colormap
+ * @brief Pick a color from a custom Chesapeake color palette
+ * @param id The id to pick from the sequence
+ */
+Color chesapeakeId(size_t id);
+
+/**
+ * @brief Get the underlying color palette for the colorbrewer colormap
  */
 const std::vector<Color>& colorbrewerPalette();
 
@@ -145,5 +151,13 @@ const std::vector<Color>& colorbrewerPalette();
  * @brief Get the underlying color palette for the distinct150 colormap
  */
 const std::vector<Color>& distinct150Palette();
+
+/**
+ * @brief Get the underlying color palette for the Chesapeake colormap.
+ *
+ * @note This colormap is based on the Chesapeake Land Cover labels defined in
+ * https://www.usgs.gov/data/chesapeake-bay-land-use-and-land-cover-lulc-database-2022-edition
+ */
+const std::vector<Color>& chesapeakePalette();
 
 }  // namespace spark_dsg::colormaps

--- a/src/colormaps.cpp
+++ b/src/colormaps.cpp
@@ -89,6 +89,22 @@ static const std::vector<Color> custom_150_palette{
     {71, 9, 82},     {224, 187, 57},  {253, 20, 130},  {127, 127, 0},   {113, 132, 132},
 };
 
+static const std::vector<Color> chesapeake_palette{
+    {255, 255, 255},  // void
+    {0, 97, 255},     // water
+    {0, 168, 132},    // emergent wetlands
+    {38, 115, 0},     // tree canopy
+    {76, 230, 0},     // scrub/shrub
+    {165, 245, 122},  // low vegetation
+    {255, 170, 0},    // barren
+    {255, 0, 0},      // impervious structures
+    {178, 178, 178},  // other impervious
+    {0, 0, 0},        // impervious roads
+    {115, 115, 0},    // tree canopy over structures
+    {205, 205, 102},  // tree canopy over other impervious
+    {255, 255, 115},  // tree canopy over impervious roads
+};
+
 Color gray(float value) {
   const auto char_value = fromUnitRange(std::clamp(value, 0.0f, 1.0f));
   return Color(char_value, char_value, char_value);
@@ -174,8 +190,15 @@ Color distinct150Id(size_t id) {
   return cmap.at(id % cmap.size());
 }
 
+Color chesapeakeId(size_t id) {
+  const auto& cmap = chesapeake_palette;
+  return cmap.at(id % cmap.size());
+}
+
 const std::vector<Color>& colorbrewerPalette() { return colorbrewer_palette; }
 
 const std::vector<Color>& distinct150Palette() { return custom_150_palette; }
+
+const std::vector<Color>& chesapeakePalette() { return chesapeake_palette; }
 
 }  // namespace spark_dsg::colormaps


### PR DESCRIPTION
This PR adds a new color palette based on the [Chesapeake Bay Land Use and Land Cover (LULC) Database](https://www.usgs.gov/data/chesapeake-bay-land-use-and-land-cover-lulc-database-2022-edition).