### PR TITLE
fix: add virtual destructor to BoundingBox::PointAdaptor

### DIFF
--- a/include/spark_dsg/bounding_box.h
+++ b/include/spark_dsg/bounding_box.h
@@ -60,6 +60,7 @@ struct BoundingBox {
    * Interface to lookup points to allow fitting a bounding box to a set of points.
    */
   struct PointAdaptor {
+    virtual ~PointAdaptor() = default;
     virtual size_t size() const = 0;
     virtual Eigen::Vector3f get(size_t index) const = 0;
     Eigen::Vector3f operator[](size_t index) const { return get(index); }


### PR DESCRIPTION
@nathanhhughes This came up when I was working on some of the image extraction work because it was using the heap pretty heavily. Here is the summary of the issue from Claude (I did confirm it makes sense and tested that the crash no longer occurs)

## Problem

`BoundingBox::PointAdaptor` is a polymorphic base class (pure-virtual `size()` and `get()`), with derived `PointVectorAdaptor` and `MeshAdaptor` — but it has **no virtual destructor**.

Consumers own a derived adaptor through a base pointer and delete it there. This came up when using Hydra's `PointNeighborSearch` holds a `std::unique_ptr<BoundingBox::PointAdaptor>` constructed from `std::make_unique<PointVectorAdaptor>(...)` and destroys it via the base pointer. Deleting a derived object through a base pointer without a virtual destructor is undefined behavior:

> **[expr.delete]/3** — "…the static type shall have a virtual destructor or the behavior is undefined."

AddressSanitizer flags this as `new-delete-type-mismatch` (a 16-byte `PointVectorAdaptor` freed as an 8-byte `PointAdaptor`). In practice it corrupts the heap and surfaces later as crashes far from the actual site (`malloc(): unaligned tcache chunk`, `malloc_consolidate(): unaligned fastbin chunk`, etc.), which makes it very hard to trace back.

## Fix

Declare a public virtual destructor on the polymorphic base, per **C++ Core Guidelines C.35** ("A base class destructor should be either public and virtual, or protected and non-virtual"):

```cpp
struct PointAdaptor {
  virtual ~PointAdaptor() = default;
  ...
};
```

One line, no behavior change. Also covers `MeshAdaptor`, which derives from the same base.

## Testing

Built and ran the full Hydra/Khronos stack with the change. The heap-corruption crash — reproduced deterministically under AddressSanitizer as the `new-delete-type-mismatch` above — is resolved, and scene-graph builds complete cleanly.


