### PR TITLE
fix: remove EIGEN_MAKE_ALIGNED_OPERATOR_NEW from node attributes (C++17 ODR hazard)

### DIFF
--- a/include/spark_dsg/node_attributes.h
+++ b/include/spark_dsg/node_attributes.h
@@ -92,7 +92,6 @@ struct NearestVertexInfo {
  */
 struct NodeAttributes {
  public:
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   friend class serialization::Visitor;
 
   //! desired node pointer type
@@ -158,7 +157,6 @@ struct NodeAttributes {
  */
 struct SemanticNodeAttributes : public NodeAttributes {
  public:
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   //! Pointer type for node
   using Ptr = std::unique_ptr<SemanticNodeAttributes>;
 
@@ -205,7 +203,6 @@ struct SemanticNodeAttributes : public NodeAttributes {
  */
 struct ObjectNodeAttributes : public SemanticNodeAttributes {
  public:
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   //! desired pointer type of node
   using Ptr = std::unique_ptr<ObjectNodeAttributes>;
 
@@ -237,7 +234,6 @@ struct ObjectNodeAttributes : public SemanticNodeAttributes {
  */
 struct RoomNodeAttributes : public SemanticNodeAttributes {
  public:
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   //! desired pointer type of node
   using Ptr = std::unique_ptr<RoomNodeAttributes>;
 
@@ -263,7 +259,6 @@ struct RoomNodeAttributes : public SemanticNodeAttributes {
  */
 struct PlaceNodeAttributes : public SemanticNodeAttributes {
  public:
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   //! desired pointer type of node
   using Ptr = std::unique_ptr<PlaceNodeAttributes>;
 
@@ -314,7 +309,6 @@ using FrontierNodeAttributes = PlaceNodeAttributes;
  */
 struct Place2dNodeAttributes : public SemanticNodeAttributes {
  public:
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   //! desired pointer type of node
   using Ptr = std::unique_ptr<Place2dNodeAttributes>;
 
@@ -353,7 +347,6 @@ struct Place2dNodeAttributes : public SemanticNodeAttributes {
 
 struct AgentNodeAttributes : public NodeAttributes {
  public:
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   using Ptr = std::unique_ptr<AgentNodeAttributes>;
   using BowIdVector = Eigen::Matrix<uint32_t, Eigen::Dynamic, 1>;
 
@@ -386,7 +379,6 @@ struct AgentNodeAttributes : public NodeAttributes {
  */
 struct KhronosObjectAttributes : public ObjectNodeAttributes {
  public:
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   //! desired pointer type of node
   using Ptr = std::unique_ptr<KhronosObjectAttributes>;
 
@@ -457,7 +449,6 @@ struct BoundaryInfo {
  */
 struct TraversabilityNodeAttributes : public SemanticNodeAttributes {
  public:
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   using Ptr = std::unique_ptr<TraversabilityNodeAttributes>;
 
   TraversabilityNodeAttributes() = default;


### PR DESCRIPTION
fix: remove EIGEN_MAKE_ALIGNED_OPERATOR_NEW from node attributes (C++17 One Definition Rule hazard) [(en.wikipedia.org/wiki/One_Definition_Rule)](en.wikipedia.org/wiki/One_Definition_Rule)

`EIGEN_MAKE_ALIGNED_OPERATOR_NEW` expands to nothing under C++17
(`EIGEN_HAS_CXX17_OVERALIGN=1`) -- Eigen considers it unnecessary there because
the compiler emits aligned `operator new` automatically. But a consumer that
defines `EIGEN_HAS_CXX17_OVERALIGN=0` flips it, in that translation unit only,
to Eigen's handmade offset `operator new`/`delete`. PCL does exactly this
(`PCLConfig.cmake` exports `-DEIGEN_HAS_CXX17_OVERALIGN=0`), so any PCL-linking
consumer compiles these attribute structs with an offset-pointer allocator,
while spark_dsg itself and non-PCL consumers compile them with none.

That is an ODR violation: the same NodeAttributes type has two definitions
across translation units, differing in their allocation operators. An
attribute allocated at base+16 (Eigen's offset) in a PCL-consuming TU is then
freed through the global sized `operator delete` on the offset pointer in a
non-PCL TU (where the deleting destructor is anchored), corrupting the heap
(`malloc(): unaligned tcache`). Confirmed with AddressSanitizer and a minimal
repro; removing the macro eliminated a real crash in a downstream consumer.

spark_dsg requires C++17/20, so the macro is pure liability here: it never adds
alignment the compiler doesn't already provide, and it makes the allocation ABI
depend on a consumer's preprocessor flag. Removing it makes the definition
identical in every translation unit regardless of any consumer #define.
