### PR TITLE
Fix/attr fwd declare

### DIFF
--- a/include/spark_dsg/edge_attributes.h
+++ b/include/spark_dsg/edge_attributes.h
@@ -50,28 +50,25 @@ template <typename T>
 using EdgeAttributeRegistration =
     serialization::AttributeRegistration<EdgeAttributes, T>;
 
-#define REGISTER_EDGE_ATTRIBUTES(attr_type)                                  \
-  inline static const auto registration_ =                                   \
-      EdgeAttributeRegistration<attr_type>(#attr_type);                      \
-  const serialization::RegistrationInfo& registrationImpl() const override { \
-    return registration_.info;                                               \
-  }                                                                          \
-  static_assert(true, "")
-
-/**
- * @brief Collection of information for an edge
- */
+//! Collection of information for an edge
 struct EdgeAttributes {
   friend class serialization::Visitor;
   //! desired pointer type for the edge attributes
   using Ptr = std::unique_ptr<EdgeAttributes>;
+
   //! Default constructor resulting in an unweight edge
   EdgeAttributes();
+
   //! Constructor that make a weighted edge
   explicit EdgeAttributes(double weight);
+
   virtual ~EdgeAttributes();
+
   //! brief Get derived copy of edge attributes
   virtual EdgeAttributes::Ptr clone() const;
+
+  //! Estimate the memory usage of the edge attributes in bytes.
+  virtual size_t memoryUsage() const;
 
   //! whether or not the edge weight is valid
   bool weighted;
@@ -90,31 +87,20 @@ struct EdgeAttributes {
 
   bool operator==(const EdgeAttributes& other) const;
 
-  const serialization::RegistrationInfo& registration() const {
-    return registrationImpl();
-  }
-
-  /**
-   * @brief Estimate the memory usage of the edge attributes in bytes.
-   */
-  virtual size_t memoryUsage() const;
+  const serialization::RegistrationInfo& registration() const;
 
  protected:
-  //! actually output information to the std::ostream
   virtual void fill_ostream(std::ostream& out) const;
-  //! register serialization information about the attributes
+
   virtual void serialization_info();
+
   virtual void serialization_info() const;
-  //! compute equality
+
   virtual bool is_equal(const EdgeAttributes& other) const;
 
-  inline static const auto registration_ =
-      EdgeAttributeRegistration<EdgeAttributes>("EdgeAttributes");
+  static const EdgeAttributeRegistration<EdgeAttributes> registration_;
 
-  //! get registration
-  virtual const serialization::RegistrationInfo& registrationImpl() const {
-    return registration_.info;
-  }
+  virtual const serialization::RegistrationInfo& registrationImpl() const;
 };
 
 }  // namespace spark_dsg

--- a/include/spark_dsg/edge_container.h
+++ b/include/spark_dsg/edge_container.h
@@ -34,10 +34,11 @@
  * -------------------------------------------------------------------------- */
 #pragma once
 #include <map>
+#include <memory>
 #include <vector>
 
+#include "spark_dsg/edge_attributes.h"
 #include "spark_dsg/scene_graph_types.h"
-#include "spark_dsg/spark_dsg_fwd.h"
 
 namespace spark_dsg {
 

--- a/include/spark_dsg/graph_utilities.h
+++ b/include/spark_dsg/graph_utilities.h
@@ -35,7 +35,6 @@
 #pragma once
 #include <deque>
 #include <functional>
-#include <queue>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>

--- a/include/spark_dsg/node_attributes.h
+++ b/include/spark_dsg/node_attributes.h
@@ -45,20 +45,9 @@
 #include "spark_dsg/bounding_box.h"
 #include "spark_dsg/color.h"
 #include "spark_dsg/mesh.h"
-#include "spark_dsg/metadata.h"
-#include "spark_dsg/scene_graph_types.h"
-#include "spark_dsg/serialization/attribute_registry.h"
+#include "spark_dsg/scene_graph_node.h"
 
 namespace spark_dsg {
-namespace serialization {
-class Visitor;
-}
-
-struct NodeAttributes;
-
-template <typename T>
-using NodeAttributeRegistration =
-    serialization::AttributeRegistration<NodeAttributes, T>;
 
 #define REGISTER_NODE_ATTRIBUTES(attr_type)                                  \
   inline static const auto attr_type##registration_ =                        \
@@ -81,75 +70,6 @@ struct NearestVertexInfo {
   double voxel_pos[3];
   size_t vertex;
   std::optional<uint32_t> label;
-};
-
-/**
- * @brief Base node attributes.
- *
- * All nodes have a pointer to node attributes (that contain most of the useful
- * information about the node). As every node has to be spatially consistent
- * with the quantity it represents, every node must have a position.
- */
-struct NodeAttributes {
- public:
-  friend class serialization::Visitor;
-
-  //! desired node pointer type
-  using Ptr = std::unique_ptr<NodeAttributes>;
-
-  //! Make a default set of attributes
-  NodeAttributes();
-  //! Set the node position
-  explicit NodeAttributes(const Eigen::Vector3d& position);
-  virtual ~NodeAttributes() = default;
-  virtual NodeAttributes::Ptr clone() const;
-
-  virtual void transform(const Eigen::Isometry3d& transform);
-
-  //! Position of the node
-  Eigen::Vector3d position;
-  //! Last time the place was updated (while active)
-  uint64_t last_update_time_ns;
-  //! Whether or not the node is in the active window
-  bool is_active;
-  //! Whether the node was observed by Hydra, or added as a prediction
-  bool is_predicted;
-  //! Arbitrary node metadata
-  Metadata metadata;
-
-  /**
-   * @brief output attribute information
-   * @param out output stream
-   * @param attrs attributes to print
-   * @returns original output stream
-   */
-  friend std::ostream& operator<<(std::ostream& out, const NodeAttributes& attrs);
-
-  bool operator==(const NodeAttributes& other) const;
-
-  const serialization::RegistrationInfo& registration() const {
-    return registrationImpl();
-  }
-
-  /**
-   * @brief Estimate the memory usage of the node attributes in bytes.
-   */
-  virtual size_t memoryUsage() const;
-
- protected:
-  virtual std::ostream& fill_ostream(std::ostream& out) const;
-  virtual void serialization_info();
-  void serialization_info() const;
-  virtual bool is_equal(const NodeAttributes& other) const;
-
- private:
-  inline static const auto registration_ =
-      NodeAttributeRegistration<NodeAttributes>("NodeAttributes");
-
- protected:
-  virtual const serialization::RegistrationInfo& registrationImpl() const {
-    return registration_.info;
-  }
 };
 
 /**

--- a/include/spark_dsg/scene_graph.h
+++ b/include/spark_dsg/scene_graph.h
@@ -36,13 +36,13 @@
 #include <Eigen/Core>
 #include <filesystem>
 #include <nlohmann/json.hpp>
-#include <type_traits>
 
 #include "spark_dsg/metadata.h"
 #include "spark_dsg/scene_graph_layer.h"
-#include "spark_dsg/spark_dsg_fwd.h"
 
 namespace spark_dsg {
+
+class Mesh;
 
 struct EdgeLayerInfo {
   LayerKey source;

--- a/include/spark_dsg/scene_graph_node.h
+++ b/include/spark_dsg/scene_graph_node.h
@@ -33,15 +33,87 @@
  * purposes notwithstanding any copyright notation herein.
  * -------------------------------------------------------------------------- */
 #pragma once
+#include <Eigen/Dense>
 #include <memory>
 #include <optional>
 #include <set>
 #include <vector>
 
+#include "spark_dsg/metadata.h"
 #include "spark_dsg/scene_graph_types.h"
-#include "spark_dsg/spark_dsg_fwd.h"
+#include "spark_dsg/serialization/attribute_registry.h"
 
 namespace spark_dsg {
+namespace serialization {
+class Visitor;
+}
+
+struct NodeAttributes;
+
+template <typename T>
+using NodeAttributeRegistration =
+    serialization::AttributeRegistration<NodeAttributes, T>;
+
+/**
+ * @brief Base node attributes.
+ *
+ * All nodes have a pointer to node attributes (that contain most of the useful
+ * information about the node). As every node has to be spatially consistent
+ * with the quantity it represents, every node must have a position.
+ */
+struct NodeAttributes {
+ public:
+  friend class serialization::Visitor;
+
+  //! desired node pointer type
+  using Ptr = std::unique_ptr<NodeAttributes>;
+
+  //! Make a default set of attributes
+  NodeAttributes();
+
+  //! Set the node position
+  explicit NodeAttributes(const Eigen::Vector3d& position);
+
+  virtual ~NodeAttributes() = default;
+
+  virtual NodeAttributes::Ptr clone() const;
+
+  //! Estimate the memory usage of the node attributes in bytes.
+  virtual size_t memoryUsage() const;
+
+  virtual void transform(const Eigen::Isometry3d& transform);
+
+  //! Position of the node
+  Eigen::Vector3d position;
+  //! Last time the place was updated (while active)
+  uint64_t last_update_time_ns;
+  //! Whether or not the node is in the active window
+  bool is_active;
+  //! Whether the node was observed by Hydra, or added as a prediction
+  bool is_predicted;
+  //! Arbitrary node metadata
+  Metadata metadata;
+
+  friend std::ostream& operator<<(std::ostream& out, const NodeAttributes& attrs);
+
+  bool operator==(const NodeAttributes& other) const;
+
+  const serialization::RegistrationInfo& registration() const;
+
+ protected:
+  virtual std::ostream& fill_ostream(std::ostream& out) const;
+
+  virtual void serialization_info();
+
+  void serialization_info() const;
+
+  virtual bool is_equal(const NodeAttributes& other) const;
+
+  virtual const serialization::RegistrationInfo& registrationImpl() const;
+
+ private:
+  static const NodeAttributeRegistration<NodeAttributes> registration_;
+};
 
 /**
  * @brief Node in the scene graph

--- a/include/spark_dsg/serialization/graph_binary_serialization.h
+++ b/include/spark_dsg/serialization/graph_binary_serialization.h
@@ -33,8 +33,9 @@
  * purposes notwithstanding any copyright notation herein.
  * -------------------------------------------------------------------------- */
 #pragma once
+#include <memory>
+#include <vector>
 
-#include "spark_dsg/serialization/versioning.h"
 #include "spark_dsg/spark_dsg_fwd.h"
 
 namespace spark_dsg::io::binary {

--- a/include/spark_dsg/serialization/graph_json_serialization.h
+++ b/include/spark_dsg/serialization/graph_json_serialization.h
@@ -33,6 +33,7 @@
  * purposes notwithstanding any copyright notation herein.
  * -------------------------------------------------------------------------- */
 #pragma once
+#include <memory>
 #include <string>
 
 #include "spark_dsg/spark_dsg_fwd.h"

--- a/include/spark_dsg/spark_dsg_fwd.h
+++ b/include/spark_dsg/spark_dsg_fwd.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <memory>
 
 namespace spark_dsg {
 

--- a/include/spark_dsg/zmq_interface.h
+++ b/include/spark_dsg/zmq_interface.h
@@ -34,6 +34,7 @@
  * -------------------------------------------------------------------------- */
 #pragma once
 
+#include <memory>
 #include <string>
 
 #include "spark_dsg/spark_dsg_fwd.h"

--- a/python/bindings/src/graph_types.cpp
+++ b/python/bindings/src/graph_types.cpp
@@ -35,10 +35,8 @@
 #include "spark_dsg/python/graph_types.h"
 
 #include <pybind11/stl.h>
-#include <spark_dsg/edge_attributes.h>
 #include <spark_dsg/edge_container.h>
 #include <spark_dsg/labelspace.h>
-#include <spark_dsg/node_attributes.h>
 #include <spark_dsg/node_symbol.h>
 #include <spark_dsg/printing.h>
 #include <spark_dsg/scene_graph_node.h>

--- a/python/bindings/src/metadata.cpp
+++ b/python/bindings/src/metadata.cpp
@@ -32,26 +32,10 @@
  * Government is authorized to reproduce and distribute reprints for Government
  * purposes notwithstanding any copyright notation herein.
  * -------------------------------------------------------------------------- */
-#include <pybind11/chrono.h>
-#include <pybind11/eigen.h>
-#include <pybind11/operators.h>
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
-#include <pybind11/stl/filesystem.h>
-#include <spark_dsg/bounding_box.h>
-#include <spark_dsg/mesh.h>
-#include <spark_dsg/node_attributes.h>
-#include <spark_dsg/node_symbol.h>
-#include <spark_dsg/printing.h>
-#include <spark_dsg/scene_graph_layer.h>
-#include <spark_dsg/scene_graph_node.h>
-#include <spark_dsg/scene_graph_types.h>
-#include <spark_dsg/scene_graph_utilities.h>
-#include <spark_dsg/serialization/graph_binary_serialization.h>
-#include <spark_dsg/serialization/versioning.h>
-#include <spark_dsg/zmq_interface.h>
+#include "spark_dsg/python/metadata.h"
 
-#include "spark_dsg/python/spark_types.h"
+#include <pybind11/pybind11.h>
+#include <spark_dsg/metadata.h>
 
 namespace spark_dsg::python {
 

--- a/python/bindings/src/python_layer_view.cpp
+++ b/python/bindings/src/python_layer_view.cpp
@@ -34,7 +34,6 @@
  * -------------------------------------------------------------------------- */
 #include "spark_dsg/python/python_layer_view.h"
 
-#include <spark_dsg/node_attributes.h>
 #include <spark_dsg/printing.h>
 
 namespace spark_dsg::python {

--- a/python/bindings/src/scene_graph.cpp
+++ b/python/bindings/src/scene_graph.cpp
@@ -38,9 +38,7 @@
 #include <pybind11/operators.h>
 #include <pybind11/stl.h>
 #include <pybind11/stl/filesystem.h>
-#include <spark_dsg/edge_attributes.h>
 #include <spark_dsg/labelspace.h>
-#include <spark_dsg/node_attributes.h>
 #include <spark_dsg/scene_graph.h>
 #include <spark_dsg/scene_graph_utilities.h>
 #include <spark_dsg/serialization/file_io.h>

--- a/python/bindings/src/scene_graph_layer.cpp
+++ b/python/bindings/src/scene_graph_layer.cpp
@@ -39,9 +39,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <pybind11/stl/filesystem.h>
-#include <spark_dsg/edge_attributes.h>
 #include <spark_dsg/graph_utilities.h>
-#include <spark_dsg/node_attributes.h>
 #include <spark_dsg/node_symbol.h>
 #include <spark_dsg/scene_graph_layer.h>
 #include <spark_dsg/serialization/graph_binary_serialization.h>

--- a/src/edge_attributes.cpp
+++ b/src/edge_attributes.cpp
@@ -34,11 +34,12 @@
  * -------------------------------------------------------------------------- */
 #include "spark_dsg/edge_attributes.h"
 
-#include <iomanip>
-
 #include "spark_dsg/serialization/attribute_serialization.h"
 
 namespace spark_dsg {
+
+decltype(EdgeAttributes::registration_) EdgeAttributes::registration_ =
+    EdgeAttributeRegistration<EdgeAttributes>("EdgeAttributes");
 
 EdgeAttributes::EdgeAttributes() : weighted(false), weight(1.0) {}
 
@@ -48,6 +49,17 @@ EdgeAttributes::~EdgeAttributes() = default;
 
 EdgeAttributes::Ptr EdgeAttributes::clone() const {
   return std::make_unique<EdgeAttributes>(*this);
+}
+
+size_t EdgeAttributes::memoryUsage() const {
+  size_t total_size = sizeof(EdgeAttributes);
+  // Metadata size (avoid double counting the Metadata struct itself).
+  total_size += metadata.memoryUsage() - sizeof(Metadata);
+  return total_size;
+}
+
+const serialization::RegistrationInfo& EdgeAttributes::registration() const {
+  return registrationImpl();
 }
 
 std::ostream& operator<<(std::ostream& out, const EdgeAttributes& attrs) {
@@ -78,11 +90,8 @@ bool EdgeAttributes::is_equal(const EdgeAttributes& other) const {
   return weighted == other.weighted && weight == other.weight;
 }
 
-size_t EdgeAttributes::memoryUsage() const {
-  size_t total_size = sizeof(EdgeAttributes);
-  // Metadata size (avoid double counting the Metadata struct itself).
-  total_size += metadata.memoryUsage() - sizeof(Metadata);
-  return total_size;
+const serialization::RegistrationInfo& EdgeAttributes::registrationImpl() const {
+  return registration_.info;
 }
 
 }  // namespace spark_dsg

--- a/src/edge_container.cpp
+++ b/src/edge_container.cpp
@@ -34,9 +34,6 @@
  * -------------------------------------------------------------------------- */
 #include "spark_dsg/edge_container.h"
 
-#include "spark_dsg/edge_attributes.h"
-#include "spark_dsg/node_symbol.h"
-
 namespace spark_dsg {
 
 using Edge = EdgeContainer::Edge;

--- a/src/graph_utilities.cpp
+++ b/src/graph_utilities.cpp
@@ -36,11 +36,10 @@
 #include "spark_dsg/graph_utilities.h"
 
 #include <functional>
+#include <list>
 #include <queue>
 #include <unordered_map>
 #include <vector>
-
-#include "spark_dsg/node_attributes.h"
 
 namespace spark_dsg::graph_utilities {
 

--- a/src/node_attributes.cpp
+++ b/src/node_attributes.cpp
@@ -34,12 +34,10 @@
  * -------------------------------------------------------------------------- */
 #include "spark_dsg/node_attributes.h"
 
-#include "spark_dsg/printing.h"
 #include "spark_dsg/serialization/attribute_serialization.h"
 #include "spark_dsg/serialization/binary_conversions.h"
 #include "spark_dsg/serialization/json_conversions.h"
 #include "spark_dsg/serialization/versioning.h"
-#include "spark_dsg/traversability_boundary.h"
 
 namespace spark_dsg {
 
@@ -73,86 +71,12 @@ std::string quatToString(const Eigen::Quaternion<Scalar>& q) {
   return ss.str();
 }
 
-template <typename Derived>
-bool matricesEqual(const Eigen::DenseBase<Derived>& lhs,
-                   const Eigen::DenseBase<Derived>& rhs) {
-  if (lhs.rows() != rhs.rows() || lhs.cols() != rhs.cols()) {
-    return false;
-  }
-
-  bool same = true;
-  for (int r = 0; r < lhs.rows(); ++r) {
-    for (int c = 0; c < lhs.cols(); ++c) {
-      const auto lhs_nan = std::isnan(lhs(r, c));
-      const auto rhs_nan = std::isnan(rhs(r, c));
-      // if one value is nan, this still works
-      same &= (lhs_nan && rhs_nan) || lhs(r, c) == rhs(r, c);
-    }
-  }
-
-  return same;
-}
-
 bool operator==(const NearestVertexInfo& lhs, const NearestVertexInfo& rhs) {
   const auto block_equal = Eigen::Map<const Eigen::Vector3i>(lhs.block) ==
                            Eigen::Map<const Eigen::Vector3i>(rhs.block);
   const auto pos_equal = Eigen::Map<const Eigen::Vector3d>(lhs.voxel_pos) ==
                          Eigen::Map<const Eigen::Vector3d>(rhs.voxel_pos);
   return block_equal && pos_equal && lhs.vertex == rhs.vertex && lhs.label == rhs.label;
-}
-
-std::ostream& operator<<(std::ostream& out, const NodeAttributes& attrs) {
-  return attrs.fill_ostream(out);
-}
-
-NodeAttributes::NodeAttributes() : NodeAttributes(Eigen::Vector3d::Zero()) {}
-
-NodeAttributes::NodeAttributes(const Eigen::Vector3d& pos)
-    : position(pos), last_update_time_ns(0), is_active(false), is_predicted(false) {}
-
-NodeAttributes::Ptr NodeAttributes::clone() const {
-  return std::make_unique<NodeAttributes>(*this);
-}
-
-void NodeAttributes::transform(const Eigen::Isometry3d& transform) {
-  position = transform * position;
-}
-
-bool NodeAttributes::operator==(const NodeAttributes& other) const {
-  return is_equal(other);
-}
-
-std::ostream& NodeAttributes::fill_ostream(std::ostream& out) const {
-  auto format = getDefaultVectorFormat();
-  out << "  - position: " << position.transpose().format(format) << "\n";
-  out << "  - last update time: "
-      << (last_update_time_ns == 0 ? "n/a" : std::to_string(last_update_time_ns))
-      << "\n";
-  out << std::boolalpha << "  - is_active: " << is_active << "\n";
-  out << std::boolalpha << "  - is_predicted: " << is_predicted;
-  return out;
-}
-
-void NodeAttributes::serialization_info() {
-  serialization::field("position", position);
-  serialization::field("last_update_time_ns", last_update_time_ns);
-  serialization::field("is_active", is_active);
-  const auto& header = io::GlobalInfo::loadedHeader();
-  if (header.version < io::Version(1, 0, 4)) {
-    io::warnOutdatedHeader(header);
-  } else {
-    serialization::field("is_predicted", is_predicted);
-  }
-}
-
-void NodeAttributes::serialization_info() const {
-  const_cast<NodeAttributes*>(this)->serialization_info();
-}
-
-bool NodeAttributes::is_equal(const NodeAttributes& other) const {
-  return matricesEqual(position, other.position) &&
-         last_update_time_ns == other.last_update_time_ns &&
-         is_active == other.is_active && is_predicted == other.is_predicted;
 }
 
 SemanticNodeAttributes::SemanticNodeAttributes()
@@ -163,15 +87,6 @@ SemanticNodeAttributes::SemanticNodeAttributes()
 
 NodeAttributes::Ptr SemanticNodeAttributes::clone() const {
   return std::make_unique<SemanticNodeAttributes>(*this);
-}
-
-size_t NodeAttributes::memoryUsage() const {
-  // By default simply dispatch serialization to estimate the attributes size. Not
-  // perfect but should be ok.
-  std::vector<uint8_t> buffer;
-  serialization::BinarySerializer serializer(&buffer);
-  serializer.write(*this);
-  return buffer.size();
 }
 
 void SemanticNodeAttributes::transform(const Eigen::Isometry3d& transform) {

--- a/src/scene_graph.cpp
+++ b/src/scene_graph.cpp
@@ -36,9 +36,7 @@
 
 #include <filesystem>
 
-#include "spark_dsg/edge_attributes.h"
 #include "spark_dsg/mesh.h"
-#include "spark_dsg/node_attributes.h"
 #include "spark_dsg/node_symbol.h"
 #include "spark_dsg/printing.h"
 #include "spark_dsg/serialization/file_io.h"

--- a/src/scene_graph_layer.cpp
+++ b/src/scene_graph_layer.cpp
@@ -36,9 +36,7 @@
 
 #include <sstream>
 
-#include "spark_dsg/edge_attributes.h"
 #include "spark_dsg/graph_utilities.h"
-#include "spark_dsg/node_attributes.h"
 #include "spark_dsg/node_symbol.h"
 #include "spark_dsg/printing.h"
 

--- a/src/scene_graph_node.cpp
+++ b/src/scene_graph_node.cpp
@@ -34,9 +34,108 @@
  * -------------------------------------------------------------------------- */
 #include "spark_dsg/scene_graph_node.h"
 
-#include "spark_dsg/node_attributes.h"
+#include "spark_dsg/printing.h"
+#include "spark_dsg/serialization/attribute_serialization.h"
+#include "spark_dsg/serialization/binary_conversions.h"
 
 namespace spark_dsg {
+namespace {
+
+template <typename Derived>
+bool matricesEqual(const Eigen::DenseBase<Derived>& lhs,
+                   const Eigen::DenseBase<Derived>& rhs) {
+  if (lhs.rows() != rhs.rows() || lhs.cols() != rhs.cols()) {
+    return false;
+  }
+
+  bool same = true;
+  for (int r = 0; r < lhs.rows(); ++r) {
+    for (int c = 0; c < lhs.cols(); ++c) {
+      const auto lhs_nan = std::isnan(lhs(r, c));
+      const auto rhs_nan = std::isnan(rhs(r, c));
+      // if one value is nan, this still works
+      same &= (lhs_nan && rhs_nan) || lhs(r, c) == rhs(r, c);
+    }
+  }
+
+  return same;
+}
+
+}  // namespace
+
+decltype(NodeAttributes::registration_) NodeAttributes::registration_ =
+    NodeAttributeRegistration<NodeAttributes>("NodeAttributes");
+
+std::ostream& operator<<(std::ostream& out, const NodeAttributes& attrs) {
+  return attrs.fill_ostream(out);
+}
+
+NodeAttributes::NodeAttributes() : NodeAttributes(Eigen::Vector3d::Zero()) {}
+
+NodeAttributes::NodeAttributes(const Eigen::Vector3d& pos)
+    : position(pos), last_update_time_ns(0), is_active(false), is_predicted(false) {}
+
+NodeAttributes::Ptr NodeAttributes::clone() const {
+  return std::make_unique<NodeAttributes>(*this);
+}
+
+size_t NodeAttributes::memoryUsage() const {
+  // By default simply dispatch serialization to estimate the attributes size. Not
+  // perfect but should be ok.
+  std::vector<uint8_t> buffer;
+  serialization::BinarySerializer serializer(&buffer);
+  serializer.write(*this);
+  return buffer.size();
+}
+
+void NodeAttributes::transform(const Eigen::Isometry3d& transform) {
+  position = transform * position;
+}
+
+bool NodeAttributes::operator==(const NodeAttributes& other) const {
+  return is_equal(other);
+}
+
+const serialization::RegistrationInfo& NodeAttributes::registration() const {
+  return registrationImpl();
+}
+
+std::ostream& NodeAttributes::fill_ostream(std::ostream& out) const {
+  auto format = getDefaultVectorFormat();
+  out << "  - position: " << position.transpose().format(format) << "\n";
+  out << "  - last update time: "
+      << (last_update_time_ns == 0 ? "n/a" : std::to_string(last_update_time_ns))
+      << "\n";
+  out << std::boolalpha << "  - is_active: " << is_active << "\n";
+  out << std::boolalpha << "  - is_predicted: " << is_predicted;
+  return out;
+}
+
+void NodeAttributes::serialization_info() {
+  serialization::field("position", position);
+  serialization::field("last_update_time_ns", last_update_time_ns);
+  serialization::field("is_active", is_active);
+  const auto& header = io::GlobalInfo::loadedHeader();
+  if (header.version < io::Version(1, 0, 4)) {
+    io::warnOutdatedHeader(header);
+  } else {
+    serialization::field("is_predicted", is_predicted);
+  }
+}
+
+void NodeAttributes::serialization_info() const {
+  const_cast<NodeAttributes*>(this)->serialization_info();
+}
+
+bool NodeAttributes::is_equal(const NodeAttributes& other) const {
+  return matricesEqual(position, other.position) &&
+         last_update_time_ns == other.last_update_time_ns &&
+         is_active == other.is_active && is_predicted == other.is_predicted;
+}
+
+const serialization::RegistrationInfo& NodeAttributes::registrationImpl() const {
+  return registration_.info;
+}
 
 SceneGraphNode::SceneGraphNode(NodeId node_id,
                                LayerKey layer_id,

--- a/src/serialization/graph_binary_serialization.cpp
+++ b/src/serialization/graph_binary_serialization.cpp
@@ -34,8 +34,7 @@
  * -------------------------------------------------------------------------- */
 #include "spark_dsg/serialization/graph_binary_serialization.h"
 
-#include "spark_dsg/edge_attributes.h"
-#include "spark_dsg/node_attributes.h"
+#include "spark_dsg/mesh.h"
 #include "spark_dsg/node_symbol.h"
 #include "spark_dsg/scene_graph.h"
 #include "spark_dsg/serialization/attribute_registry.h"

--- a/src/serialization/graph_json_serialization.cpp
+++ b/src/serialization/graph_json_serialization.cpp
@@ -34,8 +34,7 @@
  * -------------------------------------------------------------------------- */
 #include "spark_dsg/serialization/graph_json_serialization.h"
 
-#include "spark_dsg/edge_attributes.h"
-#include "spark_dsg/node_attributes.h"
+#include "spark_dsg/mesh.h"
 #include "spark_dsg/node_symbol.h"
 #include "spark_dsg/scene_graph.h"
 #include "spark_dsg/serialization/attribute_registry.h"

--- a/tests/serialization/utest_binary_conversions.cpp
+++ b/tests/serialization/utest_binary_conversions.cpp
@@ -33,8 +33,9 @@
  * purposes notwithstanding any copyright notation herein.
  * -------------------------------------------------------------------------- */
 #include <gtest/gtest.h>
+#include <spark_dsg/bounding_box.h>
+#include <spark_dsg/serialization/binary_conversions.h>
 
-#include "spark_dsg/serialization/binary_conversions.h"
 #include "spark_dsg_tests/type_comparisons.h"
 
 namespace spark_dsg {

--- a/tests/serialization/utest_json_conversions.cpp
+++ b/tests/serialization/utest_json_conversions.cpp
@@ -33,8 +33,9 @@
  * purposes notwithstanding any copyright notation herein.
  * -------------------------------------------------------------------------- */
 #include <gtest/gtest.h>
+#include <spark_dsg/bounding_box.h>
+#include <spark_dsg/serialization/json_conversions.h>
 
-#include "spark_dsg/serialization/json_conversions.h"
 #include "spark_dsg_tests/type_comparisons.h"
 
 namespace spark_dsg {

--- a/tests/spark_dsg_tests/default_attributes.h
+++ b/tests/spark_dsg_tests/default_attributes.h
@@ -1,3 +1,4 @@
+#pragma once
 #include "spark_dsg/edge_attributes.h"
 #include "spark_dsg/node_attributes.h"
 

--- a/tests/spark_dsg_tests/type_comparisons.h
+++ b/tests/spark_dsg_tests/type_comparisons.h
@@ -33,8 +33,7 @@
  * purposes notwithstanding any copyright notation herein.
  * -------------------------------------------------------------------------- */
 #pragma once
-#include <spark_dsg/edge_attributes.h>
-#include <spark_dsg/node_attributes.h>
+#include <spark_dsg/mesh.h>
 #include <spark_dsg/scene_graph.h>
 
 #include <iostream>

--- a/tests/utest_adjacency_matrix.cpp
+++ b/tests/utest_adjacency_matrix.cpp
@@ -34,8 +34,6 @@
  * -------------------------------------------------------------------------- */
 #include <gtest/gtest.h>
 #include <spark_dsg/adjacency_matrix.h>
-#include <spark_dsg/edge_attributes.h>
-#include <spark_dsg/node_attributes.h>
 #include <spark_dsg/scene_graph_layer.h>
 
 namespace spark_dsg {

--- a/tests/utest_edge_container.cpp
+++ b/tests/utest_edge_container.cpp
@@ -33,7 +33,6 @@
  * purposes notwithstanding any copyright notation herein.
  * -------------------------------------------------------------------------- */
 #include <gtest/gtest.h>
-#include <spark_dsg/edge_attributes.h>
 #include <spark_dsg/edge_container.h>
 
 namespace spark_dsg {

--- a/tests/utest_graph_utilities.cpp
+++ b/tests/utest_graph_utilities.cpp
@@ -33,9 +33,7 @@
  * purposes notwithstanding any copyright notation herein.
  * -------------------------------------------------------------------------- */
 #include <gtest/gtest.h>
-#include <spark_dsg/edge_attributes.h>
 #include <spark_dsg/graph_utilities.h>
-#include <spark_dsg/node_attributes.h>
 #include <spark_dsg/printing.h>
 #include <spark_dsg/scene_graph_layer.h>
 

--- a/tests/utest_memory_usage.cpp
+++ b/tests/utest_memory_usage.cpp
@@ -33,7 +33,6 @@
  * purposes notwithstanding any copyright notation herein.
  * -------------------------------------------------------------------------- */
 #include <gtest/gtest.h>
-#include <spark_dsg/edge_attributes.h>
 #include <spark_dsg/edge_container.h>
 #include <spark_dsg/mesh.h>
 #include <spark_dsg/metadata.h>

--- a/tests/utest_scene_graph_node.cpp
+++ b/tests/utest_scene_graph_node.cpp
@@ -33,7 +33,6 @@
  * purposes notwithstanding any copyright notation herein.
  * -------------------------------------------------------------------------- */
 #include <gtest/gtest.h>
-#include <spark_dsg/node_attributes.h>
 #include <spark_dsg/scene_graph_node.h>
 
 using namespace spark_dsg;

--- a/tests/utest_scene_graph_utilities.cpp
+++ b/tests/utest_scene_graph_utilities.cpp
@@ -33,11 +33,9 @@
  * purposes notwithstanding any copyright notation herein.
  * -------------------------------------------------------------------------- */
 #include <gtest/gtest.h>
-#include <spark_dsg/node_attributes.h>
 #include <spark_dsg/printing.h>
+#include <spark_dsg/scene_graph.h>
 #include <spark_dsg/scene_graph_utilities.h>
-
-#include "spark_dsg_tests/type_comparisons.h"
 
 namespace spark_dsg {
 


### PR DESCRIPTION
Moves base `NodeAttributes` so that `SceneGraphNode` no longer requires forward-declare of `NodeAttributes` and include `edge_attributes.h` so that `EdgeContainer` no longer requires forward-declare of `EdgeAttributes` (allows including `scene_graph_layer.h` downstream without also requiring `edge_attributes.h` or `node_attributes.h`)