### PR TITLE
Fix RAABB enclosure with a robust convex hull

### DIFF
--- a/include/spark_dsg/bounding_box_extraction.h
+++ b/include/spark_dsg/bounding_box_extraction.h
@@ -53,12 +53,10 @@ struct BoxResult2D {
 /**
  * @brief compute 2D convex hull in x-y plane
  *
- * Exposed primarily for testing
- *
  * @param points Point adaptor to use
  * @returns indices of hull points in ccw order
  */
-std::list<size_t> get2dConvexHull(const PointAdaptor& points);
+std::vector<size_t> get2dConvexHull(const PointAdaptor& points);
 
 /**
  * @brief compute the minimum area bounding box in the x-y plane

--- a/include/spark_dsg/bounding_box_extraction.h
+++ b/include/spark_dsg/bounding_box_extraction.h
@@ -33,8 +33,8 @@
  * purposes notwithstanding any copyright notation herein.
  * -------------------------------------------------------------------------- */
 #pragma once
-#include <list>
 #include <optional>
+#include <vector>
 
 #include "spark_dsg/bounding_box.h"
 
@@ -61,13 +61,12 @@ std::vector<size_t> get2dConvexHull(const PointAdaptor& points);
 /**
  * @brief compute the minimum area bounding box in the x-y plane
  *
- * Exposed primarily for testing
- *
  * @param points Point adapter to use
  * @param hull Optional convex hull
  * @returns resulting bounding box if one exists
  */
-BoxResult2D getMin2DBox(const PointAdaptor& points, const std::list<size_t>& hull = {});
+BoxResult2D getMin2DBox(const PointAdaptor& points,
+                        const std::vector<size_t>& hull = {});
 
 /**
  * @brief construct a bounding box directly from a pointcloud

--- a/python/bindings/src/bounding_box.cpp
+++ b/python/bindings/src/bounding_box.cpp
@@ -101,7 +101,7 @@ void init_bounding_box(py::module_& m) {
 
   m.def(
       "get_min_2d_box",
-      [](const std::vector<Eigen::Vector3f>& points, const std::list<size_t>& hull) -> std::optional<BoxResult2D> {
+      [](const std::vector<Eigen::Vector3f>& points, const std::vector<size_t>& hull) -> std::optional<BoxResult2D> {
         BoundingBox::PointVectorAdaptor adaptor(points);
         const auto result = bounding_box::getMin2DBox(adaptor, hull);
         return !result.min_area ? std::nullopt : std::optional<BoxResult2D>(result);

--- a/src/bounding_box_extraction.cpp
+++ b/src/bounding_box_extraction.cpp
@@ -34,88 +34,79 @@
  * -------------------------------------------------------------------------- */
 #include "spark_dsg/bounding_box_extraction.h"
 
+#include <algorithm>
+#include <functional>
+#include <iterator>
+#include <limits>
+#include <numeric>
 #include <optional>
 
-namespace spark_dsg {
-namespace bounding_box {
+namespace spark_dsg::bounding_box {
+namespace {
 
-float getAngle(const Eigen::Vector3f& curr, const Eigen::Vector3f& root) {
-  const Eigen::Vector2f vec = (curr.head<2>() - root.head<2>()).normalized();
-  // range of x should be between 1 and -1 (with y >= 0)
-  // we want function mapping [1, -1] to [0, c]
-  return 1.0f - vec.x();
+bool comparePoints(const PointAdaptor& points, size_t i, size_t j) {
+  const auto p_i = points[i];
+  const auto p_j = points[j];
+  return p_i.x() < p_j.x() || (p_i.x() == p_j.x() && p_i.y() < p_j.y());
 }
 
-float getDist(const Eigen::Vector3f& curr, const Eigen::Vector3f& root) {
-  return (curr.head<2>() - root.head<2>()).array().abs().sum();
+bool equalPointsXY(const PointAdaptor& points, size_t i, size_t j) {
+  return points[i].head<2>() == points[j].head<2>();
 }
 
-float getJointDirection(const Eigen::Vector3f& prev,
-                        const Eigen::Vector3f& curr,
-                        const Eigen::Vector3f& next) {
-  const Eigen::Vector2f v1 = curr.head<2>() - prev.head<2>();
-  const Eigen::Vector2f v2 = next.head<2>() - prev.head<2>();
+double getJointDirection(const Eigen::Vector3f& prev,
+                         const Eigen::Vector3f& curr,
+                         const Eigen::Vector3f& next) {
+  const Eigen::Vector2d root = prev.head<2>().cast<double>();
+  const Eigen::Vector2d v1 = curr.head<2>().cast<double>() - root;
+  const Eigen::Vector2d v2 = next.head<2>().cast<double>() - root;
   return v1.x() * v2.y() - v1.y() * v2.x();
 }
 
+void appendHullPoint(const PointAdaptor& points,
+                     size_t index,
+                     size_t begin,
+                     std::vector<size_t>& hull) {
+  while (hull.size() >= begin + 2) {
+    const auto prev = hull[hull.size() - 2];
+    const auto curr = hull.back();
+    const auto direction = getJointDirection(points[prev], points[curr], points[index]);
+    if (direction > 0.0) {
+      break;
+    }
+
+    hull.pop_back();
+  }
+
+  hull.push_back(index);
+}
+
+}  // namespace
+
 std::list<size_t> get2dConvexHull(const PointAdaptor& points) {
-  size_t root = 0;
-  Eigen::Vector3f root_pos = points[0];
-  for (size_t i = 0; i < points.size(); ++i) {
-    const auto curr_pos = points[i];
-    if (curr_pos.y() > root_pos.y()) {
-      continue;
-    }
-
-    if (curr_pos.y() == root_pos.y() && curr_pos.x() > root_pos.x()) {
-      continue;
-    }
-
-    root_pos = curr_pos;
-    root = i;
-  }
-
-  const auto compare = [&](size_t i, size_t j) -> bool {
-    const auto p_i = points[i];
-    const auto p_j = points[j];
-    const auto a_i = getAngle(p_i, root_pos);
-    const auto a_j = getAngle(p_j, root_pos);
-    if (std::abs(a_i - a_j) < 1.0e-9f) {
-      const auto d_i = getDist(p_i, root_pos);
-      const auto d_j = getDist(p_j, root_pos);
-      return d_i < d_j;
-    } else {
-      return a_i < a_j;
-    }
-  };
-
-  std::vector<size_t> indices;
-  for (size_t i = 0; i < points.size(); ++i) {
-    if (i != root) {
-      indices.push_back(i);
-    }
-  }
-
+  using namespace std::placeholders;
+  std::vector<size_t> indices(points.size());
+  std::iota(indices.begin(), indices.end(), size_t{0});
+  const auto compare = std::bind(comparePoints, std::cref(points), _1, _2);
   std::sort(indices.begin(), indices.end(), compare);
-
-  std::list<size_t> hull{root};
-  for (const auto& idx : indices) {
-    while (hull.size() > 1) {
-      auto prev = --hull.cend();
-      auto curr = prev;
-      --curr;
-      const auto angle = getJointDirection(points[*prev], points[*curr], points[idx]);
-      if (angle < 0.0f) {
-        break;
-      }
-
-      hull.pop_back();
-    }
-
-    hull.push_back(idx);
+  const auto equal = std::bind(equalPointsXY, std::cref(points), _1, _2);
+  indices.erase(std::unique(indices.begin(), indices.end(), equal), indices.end());
+  if (indices.size() <= 1) {
+    return {indices.begin(), indices.end()};
   }
 
-  return hull;
+  std::vector<size_t> hull;
+  for (const auto index : indices) {
+    appendHullPoint(points, index, 0, hull);
+  }
+
+  const auto upper_begin = hull.size() - 1;
+  for (auto iter = std::next(indices.rbegin()); iter != indices.rend(); ++iter) {
+    appendHullPoint(points, *iter, upper_begin, hull);
+  }
+
+  hull.pop_back();  // The first point closes both chains.
+  return {hull.begin(), hull.end()};
 }
 
 BoxResult2D getMin2DBox(const PointAdaptor& points, const std::list<size_t>& hull) {
@@ -132,54 +123,50 @@ BoxResult2D getMin2DBox(const PointAdaptor& points, const std::list<size_t>& hul
     return result;
   }
 
-  // technically this can be implemented in O(n) instead via rotation calipers,
-  // but this is easier to understand and n << points.size() due to 2d projection
+  if (indices.size() == 2) {
+    const Eigen::Vector2d a = points[indices.front()].head<2>().cast<double>();
+    const Eigen::Vector2d b = points[indices.back()].head<2>().cast<double>();
+    const Eigen::Vector2d edge = b - a;
+    result.min_area = 0.0f;
+    result.dims << edge.norm(), 0.0f;
+    result.center = (a + 0.5 * edge).cast<float>();
+    result.yaw = std::atan2(edge.y(), edge.x());
+    return result;
+  }
+
+  // Evaluate each hull edge; the hull is small compared to the input cloud.
+  double min_area = std::numeric_limits<double>::infinity();
   for (size_t i = 0; i < indices.size(); ++i) {
-    const auto curr_idx = indices[i];
-    const auto next_idx = indices[(i + 1) % indices.size()];
-    const Eigen::Vector2f p_c = points[curr_idx].head<2>();
-    const Eigen::Vector2f p_n = points[next_idx].head<2>();
-    // normals and offsets for height / width hyperplanes and local coordinates
-    const Eigen::Vector2f n_x = (p_n - p_c).normalized();
-    const Eigen::Vector2f n_y(-n_x.y(), n_x.x());  // equivalent to a 90 degree rotation
-    const auto b_x = -n_x.dot(p_c);
-    const auto b_y = -n_y.dot(p_c);
-    // distances from hyperplanes (all points will be above 0 for y hyperplane)
-    float max_y = 0.0f;
-    float min_x = 0.0f;  // only points with negative distance will override this
-    float max_x = 0.0f;
-    for (size_t j = 1; j < indices.size(); ++j) {
-      const Eigen::Vector2f p_j = points[indices[(i + j) % indices.size()]].head<2>();
-      const auto x_dist = n_x.dot(p_j) + b_x;
-      if (x_dist <= min_x) {
-        min_x = x_dist;
-      }
-
-      if (x_dist >= max_x) {
-        max_x = x_dist;
-      }
-
-      const auto y_dist = n_y.dot(p_j) + b_y;
-      if (y_dist >= max_y) {
-        max_y = y_dist;
-      }
-    }
-
-    // technically (max_y - min_x) * (max_y - min_x) but min_y is 0
-    const auto area = max_y * (max_x - min_x);
-    if (result.min_area && area >= *result.min_area) {
+    const Eigen::Vector2d origin = points[indices[i]].head<2>().cast<double>();
+    const Eigen::Vector2d edge =
+        points[indices[(i + 1) % indices.size()]].head<2>().cast<double>() - origin;
+    if (edge.squaredNorm() == 0.0) {
       continue;
     }
 
-    result.min_area = area;
-    result.dims << max_x - min_x, max_y;
-    result.yaw = std::atan2(n_x.y(), n_x.x());
+    Eigen::Matrix2d rotation;
+    rotation.col(0) = edge.normalized();
+    rotation.col(1) = Eigen::Vector2d(-rotation(1, 0), rotation(0, 0));
+    Eigen::Vector2d min = Eigen::Vector2d::Zero();
+    Eigen::Vector2d max = Eigen::Vector2d::Zero();
+    for (const auto index : indices) {
+      const Eigen::Vector2d offset = points[index].head<2>().cast<double>() - origin;
+      const Eigen::Vector2d local = rotation.transpose() * offset;
+      min = min.cwiseMin(local);
+      max = max.cwiseMax(local);
+    }
 
-    // transform center point to global coordinates
-    Eigen::Matrix2f R;
-    R.col(0) = n_x;
-    R.col(1) = n_y;
-    result.center = R * (0.5 * result.dims + Eigen::Vector2f(min_x, 0.0f)) + p_c;
+    const Eigen::Vector2d dims = max - min;
+    const auto area = dims.prod();
+    if (area >= min_area) {
+      continue;
+    }
+
+    min_area = area;
+    result.min_area = static_cast<float>(area);
+    result.dims = dims.cast<float>();
+    result.yaw = std::atan2(rotation(1, 0), rotation(0, 0));
+    result.center = (origin + rotation * (0.5 * (min + max))).cast<float>();
   }
 
   return result;
@@ -236,6 +223,4 @@ BoundingBox extract(const PointAdaptor& points, BoundingBox::Type type) {
   }
 }
 
-}  // namespace bounding_box
-
-}  // namespace spark_dsg
+}  // namespace spark_dsg::bounding_box

--- a/src/bounding_box_extraction.cpp
+++ b/src/bounding_box_extraction.cpp
@@ -109,13 +109,12 @@ std::vector<size_t> get2dConvexHull(const PointAdaptor& points) {
   return hull;
 }
 
-BoxResult2D getMin2DBox(const PointAdaptor& points, const std::list<size_t>& hull) {
+BoxResult2D getMin2DBox(const PointAdaptor& points, const std::vector<size_t>& hull) {
   std::vector<size_t> indices;
   if (hull.empty()) {
-    const auto new_hull = get2dConvexHull(points);
-    indices.insert(indices.end(), new_hull.begin(), new_hull.end());
+    indices = get2dConvexHull(points);
   } else {
-    indices.insert(indices.end(), hull.begin(), hull.end());
+    indices = hull;
   }
 
   BoxResult2D result;

--- a/src/bounding_box_extraction.cpp
+++ b/src/bounding_box_extraction.cpp
@@ -37,7 +37,6 @@
 #include <algorithm>
 #include <functional>
 #include <iterator>
-#include <limits>
 #include <numeric>
 #include <optional>
 
@@ -83,7 +82,7 @@ void appendHullPoint(const PointAdaptor& points,
 
 }  // namespace
 
-std::list<size_t> get2dConvexHull(const PointAdaptor& points) {
+std::vector<size_t> get2dConvexHull(const PointAdaptor& points) {
   using namespace std::placeholders;
   std::vector<size_t> indices(points.size());
   std::iota(indices.begin(), indices.end(), size_t{0});
@@ -96,6 +95,7 @@ std::list<size_t> get2dConvexHull(const PointAdaptor& points) {
   }
 
   std::vector<size_t> hull;
+  hull.reserve(points.size());
   for (const auto index : indices) {
     appendHullPoint(points, index, 0, hull);
   }
@@ -106,7 +106,7 @@ std::list<size_t> get2dConvexHull(const PointAdaptor& points) {
   }
 
   hull.pop_back();  // The first point closes both chains.
-  return {hull.begin(), hull.end()};
+  return hull;
 }
 
 BoxResult2D getMin2DBox(const PointAdaptor& points, const std::list<size_t>& hull) {
@@ -134,39 +134,41 @@ BoxResult2D getMin2DBox(const PointAdaptor& points, const std::list<size_t>& hul
     return result;
   }
 
-  // Evaluate each hull edge; the hull is small compared to the input cloud.
-  double min_area = std::numeric_limits<double>::infinity();
+  // technically this can be implemented in O(n) instead via rotation calipers,
+  // but this is easier to understand and n << points.size() due to 2d projection
   for (size_t i = 0; i < indices.size(); ++i) {
-    const Eigen::Vector2d origin = points[indices[i]].head<2>().cast<double>();
-    const Eigen::Vector2d edge =
-        points[indices[(i + 1) % indices.size()]].head<2>().cast<double>() - origin;
+    const auto curr_idx = indices[i];
+    const auto next_idx = indices[(i + 1) % indices.size()];
+    const Eigen::Vector2d p_c = points[curr_idx].head<2>().cast<double>();
+    const Eigen::Vector2d p_n = points[next_idx].head<2>().cast<double>();
+    const Eigen::Vector2d edge = p_n - p_c;
     if (edge.squaredNorm() == 0.0) {
       continue;
     }
 
-    Eigen::Matrix2d rotation;
-    rotation.col(0) = edge.normalized();
-    rotation.col(1) = Eigen::Vector2d(-rotation(1, 0), rotation(0, 0));
+    Eigen::Matrix2d R;
+    R.col(0) = edge.normalized();
+    R.col(1) = Eigen::Vector2d(-R(1, 0), R(0, 0));
     Eigen::Vector2d min = Eigen::Vector2d::Zero();
     Eigen::Vector2d max = Eigen::Vector2d::Zero();
     for (const auto index : indices) {
-      const Eigen::Vector2d offset = points[index].head<2>().cast<double>() - origin;
-      const Eigen::Vector2d local = rotation.transpose() * offset;
+      const Eigen::Vector2d offset = points[index].head<2>().cast<double>() - p_c;
+      const Eigen::Vector2d local = R.transpose() * offset;
       min = min.cwiseMin(local);
       max = max.cwiseMax(local);
     }
 
     const Eigen::Vector2d dims = max - min;
     const auto area = dims.prod();
-    if (area >= min_area) {
+    if (result.min_area && area >= *result.min_area) {
       continue;
     }
 
-    min_area = area;
-    result.min_area = static_cast<float>(area);
+    result.min_area = area;
     result.dims = dims.cast<float>();
-    result.yaw = std::atan2(rotation(1, 0), rotation(0, 0));
-    result.center = (origin + rotation * (0.5 * (min + max))).cast<float>();
+    result.yaw = std::atan2(R(1, 0), R(0, 0));
+    // transform center point to global coordinates
+    result.center = (R * (0.5 * (min + max)) + p_c).cast<float>();
   }
 
   return result;

--- a/src/node_attributes.cpp
+++ b/src/node_attributes.cpp
@@ -34,6 +34,8 @@
  * -------------------------------------------------------------------------- */
 #include "spark_dsg/node_attributes.h"
 
+#include <numbers>
+
 #include "spark_dsg/serialization/attribute_serialization.h"
 #include "spark_dsg/serialization/binary_conversions.h"
 #include "spark_dsg/serialization/json_conversions.h"
@@ -710,7 +712,7 @@ void TravNodeAttributes::clear() {
 }
 
 double TravNodeAttributes::getBinPercentage(const Eigen::Vector3d& point_L) const {
-  const double angle = std::atan2(point_L.y(), point_L.x()) / (2.0 * M_PI);
+  const double angle = std::atan2(point_L.y(), point_L.x()) / (2.0 * std::numbers::pi);
   return angle >= 0.0 ? angle : angle + 1.0;
 }
 
@@ -740,8 +742,8 @@ bool TravNodeAttributes::contains(const Eigen::Vector3d& point_W) const {
 
 Eigen::Vector3d TravNodeAttributes::getBoundaryPoint(size_t bin,
                                                      bool in_world_frame) const {
-  const double angle =
-      (static_cast<double>(bin) / static_cast<double>(radii.size())) * 2.0 * M_PI;
+  const double angle = (static_cast<double>(bin) / static_cast<double>(radii.size())) *
+                       2.0 * std::numbers::pi;
   const Eigen::Vector3d point_L(
       radii[bin] * std::cos(angle), radii[bin] * std::sin(angle), 0.0);
   if (in_world_frame) {
@@ -773,7 +775,8 @@ bool TravNodeAttributes::intersects(const TravNodeAttributes& other) const {
 double TravNodeAttributes::area() const {
   double area = 0.0;
   const size_t N = radii.size();
-  const double angle_increment = std::sin((2.0 * M_PI) / static_cast<double>(N));
+  const double angle_increment =
+      std::sin((2.0 * std::numbers::pi) / static_cast<double>(N));
   for (size_t i = 0; i < N; ++i) {
     const double r1 = radii[i];
     const double r2 = radii[(i + 1) % N];

--- a/tests/utest_bounding_box.cpp
+++ b/tests/utest_bounding_box.cpp
@@ -400,7 +400,7 @@ TEST(BoundingBoxTests, frameConversions) {
   EXPECT_NEAR(-1, p4(2), 1.0e-6f);
 }
 
-TEST(BoundingBoxTests, merge) {
+TEST(BoundingBoxTests, MergeCorrect) {
   // Aligned AABB.
   BoundingBox box1(Eigen::Vector3f(1, 2, 3), Eigen::Vector3f(0.5, 1.0, 1.5));
   BoundingBox box2(Eigen::Vector3f(3, 2, 1), Eigen::Vector3f(0.5, 1.0, 1.5));
@@ -422,12 +422,11 @@ TEST(BoundingBoxTests, merge) {
                      Eigen::Vector3f(0.5, 1.0, 1.5),
                      std::numbers::pi / 6);
   box1.merge(box2);
-  const float yaw = box1.world_R_center.eulerAngles(0, 1, 2)[2];
   // The solution finds the 90deg rotated box, i.e. y=x and yaw=-60deg from 30 deg.
-  EXPECT_NEAR(2, box1.dimensions(0), 1.0e-6f);
-  EXPECT_NEAR(1.5, box1.dimensions(1), 1.0e-6f);
-  EXPECT_NEAR(3, box1.dimensions(2), 1.0e-6f);
-  EXPECT_NEAR(-std::numbers::pi / 3, yaw, 1.0e-6f);
+  const auto expected = BoundingBox(Eigen::Vector3f(2, 1.5, 3),
+                                    Eigen::Vector3f(0.5, 1.0, 1.5),
+                                    -std::numbers::pi / 3);
+  EXPECT_NEAR(box1.computeIoU(expected), 1.0, 1.0e-2f);
 }
 
 }  // namespace spark_dsg

--- a/tests/utest_bounding_box_extraction.cpp
+++ b/tests/utest_bounding_box_extraction.cpp
@@ -36,6 +36,8 @@
 #include <spark_dsg/bounding_box_extraction.h>
 
 #include <Eigen/Geometry>
+#include <algorithm>
+#include <limits>
 #include <numbers>
 
 namespace spark_dsg {
@@ -69,6 +71,51 @@ inline float computeIoU(const BoxResult2D& lhs, const BoxResult2D& rhs) {
                       Eigen::Vector3f(rhs.center.x(), rhs.center.y(), 0.0),
                       rhs.yaw);
   return box_lhs.computeIoU(box_rhs);
+}
+
+void checkEnclosure(const std::vector<Eigen::Vector3f>& points,
+                    double expected_area,
+                    double area_tolerance) {
+  const BoundingBox::PointVectorAdaptor adaptor(points);
+  const auto hull = bounding_box::get2dConvexHull(adaptor);
+  ASSERT_GE(hull.size(), 3u);
+  std::vector<size_t> indices(hull.begin(), hull.end());
+  for (size_t i = 0; i < indices.size(); ++i) {
+    const Eigen::Vector2d a = points[indices[i]].head<2>().cast<double>();
+    const Eigen::Vector2d edge =
+        points[indices[(i + 1) % indices.size()]].head<2>().cast<double>() - a;
+    for (const auto& point : points) {
+      const Eigen::Vector2d offset = point.head<2>().cast<double>() - a;
+      EXPECT_GE(edge.x() * offset.y() - edge.y() * offset.x(), -1.0e-12);
+    }
+  }
+
+  const BoundingBox box(points, BoundingBox::Type::RAABB);
+  ASSERT_TRUE(box.isValid());
+  EXPECT_NEAR(static_cast<double>(box.dimensions.x()) * box.dimensions.y(),
+              expected_area,
+              area_tolerance);
+  for (const auto& point : points) {
+    const Eigen::Vector3d local =
+        box.world_R_center.cast<double>().transpose() *
+        (point.cast<double>() - box.world_P_center.cast<double>());
+    // Float center, dimensions and rotation each round once. Account for their
+    // scale, including center rounding for boxes far from the origin.
+    const double tolerance = 4.0 * std::numeric_limits<float>::epsilon() *
+                             (point.cast<double>().cwiseAbs().maxCoeff() +
+                              box.dimensions.cast<double>().maxCoeff());
+    EXPECT_LE((local.cwiseAbs() - box.dimensions.cast<double>() / 2.0).maxCoeff(),
+              tolerance);
+  }
+}
+
+std::vector<Eigen::Vector3f> angularTiePoints() {
+  // Minimized from the saved trashcan. The first two directions from the last
+  // point share a float angle key despite having different polar angles.
+  return {{-8.850000381469727f, 31.249998092651367f, 1.047795295715332f},
+          {-8.849999427795410f, 31.249998092651367f, 1.354702115058899f},
+          {-8.843938827514648f, 31.250000000000000f, 1.049999952316284f},
+          {-9.349999427795410f, 31.192356109619140f, 1.149999976158142f}};
 }
 
 }  // namespace
@@ -247,15 +294,15 @@ TEST(BoundingBoxExtraction, RAABBFromPoints) {
   // get bounding box from pointcloud
   BoundingBox box = bounding_box::extract(adaptor, BoundingBox::Type::RAABB);
   EXPECT_EQ(BoundingBox::Type::RAABB, box.type);
-  EXPECT_NEAR(5.0f, box.dimensions(0), 1.0e-6);
-  EXPECT_NEAR(2.5f, box.dimensions(1), 1.0e-6);
-  EXPECT_NEAR(1.0f, box.dimensions(2), 1.0e-6);
-  EXPECT_NEAR(2.5f, box.world_P_center(0), 1.0e-6);
-  EXPECT_NEAR(1.25f, box.world_P_center(1), 1.0e-6);
-  EXPECT_NEAR(0.5f, box.world_P_center(2), 1.0e-6);
-
-  Eigen::Quaternionf expected_rotation = Eigen::Quaternionf::Identity();
-  EXPECT_NEAR(0.0f, getRotationError(expected_rotation, box), 1.0e-6f);
+  // This triangle has several minimum rectangles with different centers/yaws.
+  EXPECT_NEAR(12.5f, box.dimensions.x() * box.dimensions.y(), 1.0e-5f);
+  EXPECT_NEAR(1.0f, box.dimensions.z(), 1.0e-6f);
+  EXPECT_NEAR(0.5f, box.world_P_center.z(), 1.0e-6f);
+  for (size_t i = 0; i < adaptor.size(); ++i) {
+    const Eigen::Vector3f local =
+        box.world_R_center.transpose() * (adaptor[i] - box.world_P_center);
+    EXPECT_LE((local.cwiseAbs() - box.dimensions / 2.0f).maxCoeff(), 1.0e-6f);
+  }
 }
 
 TEST(BoundingBoxExtraction, RAABBFromPointsNonTrivial) {
@@ -296,6 +343,97 @@ TEST(BoundingBoxExtraction, RAABBFromPointsNonTrivial) {
   const BoundingBox expected(
       Eigen::Vector3f(length, width, height), expected_pos, angle);
   EXPECT_NEAR(1.0f, box.computeIoU(expected, 5000), 1.0e-2f);
+}
+
+TEST(BoundingBoxExtraction, AngularTieEnclosure) {
+  const auto original = angularTiePoints();
+  std::array<size_t, 4> order{0, 1, 2, 3};
+  do {
+    std::vector<Eigen::Vector3f> points;
+    for (const auto i : order) {
+      points.push_back(original[i]);
+    }
+
+    // Independent minimum rectangle of the represented float coordinates.
+    checkEnclosure(points, 0.00034844631772374903, 1.0e-10);
+  } while (std::next_permutation(order.begin(), order.end()));
+}
+
+TEST(BoundingBoxExtraction, ThinRectangleFromSuppliedHull) {
+  const auto points = angularTiePoints();
+  const BoundingBox::PointVectorAdaptor adaptor(points);
+  for (const auto& hull : {std::list<size_t>{3, 2, 0}, std::list<size_t>{0, 2, 3}}) {
+    const auto result = bounding_box::getMin2DBox(adaptor, hull);
+    ASSERT_TRUE(result.min_area);
+    EXPECT_NEAR(*result.min_area, 0.00034844631772374903, 1.0e-10);
+  }
+}
+
+TEST(BoundingBoxExtraction, RepeatedRotatedTranslatedPoints) {
+  for (const float width : {0.0001f, 0.5f}) {
+    for (const float angle : {0.0f, 0.3f, 1.7f, -2.4f}) {
+      for (const float distance : {0.0f, 32.0f, 10000.0f}) {
+        // At 10 km, float coordinates cannot represent the thin rectangle.
+        if (width < 0.001f && distance > 100.0f) {
+          continue;
+        }
+
+        const Eigen::AngleAxisf rotation(angle, Eigen::Vector3f::UnitZ());
+        const Eigen::Vector3f translation(distance, -distance, distance);
+        std::vector<Eigen::Vector3f> points;
+        for (const float x : {0.0f, 1.0f, 2.0f}) {
+          for (const float y : {0.0f, width}) {
+            for (const float z : {0.0f, 0.75f}) {
+              const Eigen::Vector3f point =
+                  rotation * Eigen::Vector3f(x, y, z) + translation;
+              points.push_back(point);
+              points.push_back(point);
+            }
+          }
+        }
+
+        // Coordinate quantization perturbs the nominal area by perimeter times
+        // coordinate error. The factor also covers float output rounding.
+        const double area_tolerance =
+            16.0 * std::numeric_limits<float>::epsilon() * (distance + 2.0f);
+        checkEnclosure(points, 2.0 * width, area_tolerance);
+        std::reverse(points.begin(), points.end());
+        checkEnclosure(points, 2.0 * width, area_tolerance);
+      }
+    }
+  }
+}
+
+TEST(BoundingBoxExtraction, DegenerateHullInputs) {
+  std::vector<Eigen::Vector3f> points;
+  const BoundingBox::PointVectorAdaptor adaptor(points);
+  EXPECT_TRUE(bounding_box::get2dConvexHull(adaptor).empty());
+  EXPECT_FALSE(bounding_box::getMin2DBox(adaptor).min_area);
+  EXPECT_EQ(BoundingBox(points, BoundingBox::Type::RAABB).type,
+            BoundingBox::Type::INVALID);
+  points = {{1.0f, 2.0f, 0.0f}};
+  EXPECT_EQ(bounding_box::get2dConvexHull(adaptor).size(), 1u);
+  EXPECT_EQ(BoundingBox(points, BoundingBox::Type::RAABB).type,
+            BoundingBox::Type::INVALID);
+  points.push_back({1.0f, 2.0f, 4.0f});
+  EXPECT_EQ(bounding_box::get2dConvexHull(adaptor).size(), 1u);
+  EXPECT_EQ(BoundingBox(points, BoundingBox::Type::RAABB).type,
+            BoundingBox::Type::INVALID);
+  points.insert(points.end(), {{2.0f, 2.0f, 1.0f}, {3.0f, 2.0f, 2.0f}});
+  EXPECT_EQ(bounding_box::get2dConvexHull(adaptor).size(), 2u);
+  const BoundingBox box(points, BoundingBox::Type::RAABB);
+  EXPECT_EQ(box.type, BoundingBox::Type::RAABB);
+  EXPECT_FALSE(box.isValid());
+  EXPECT_EQ(box.dimensions, Eigen::Vector3f(2.0f, 0.0f, 4.0f));
+  EXPECT_EQ(box.world_P_center, Eigen::Vector3f(2.0f, 2.0f, 2.0f));
+  points = {{0.0f, 0.0f, 0.0f}, {1.0f, 3.0f, 1.0f}, {2.0f, 6.0f, 2.0f}};
+  const BoundingBox diagonal(points, BoundingBox::Type::RAABB);
+  EXPECT_EQ(bounding_box::get2dConvexHull(adaptor).size(), 2u);
+  EXPECT_EQ(diagonal.type, BoundingBox::Type::RAABB);
+  EXPECT_FALSE(diagonal.isValid());
+  EXPECT_EQ(diagonal.dimensions.y(), 0.0f);
+  EXPECT_NEAR(diagonal.dimensions.x(), std::sqrt(40.0f), 1.0e-6f);
+  EXPECT_EQ(diagonal.world_P_center, Eigen::Vector3f(1.0f, 3.0f, 1.0f));
 }
 
 }  // namespace spark_dsg

--- a/tests/utest_bounding_box_extraction.cpp
+++ b/tests/utest_bounding_box_extraction.cpp
@@ -136,7 +136,7 @@ TEST(BoundingBoxExtraction, ConvexHull) {
   };
 
   const auto hull = bounding_box::get2dConvexHull(adaptor);
-  std::list<size_t> expected{8, 0, 6, 4};
+  std::vector<size_t> expected{8, 0, 6, 4};
   EXPECT_EQ(hull, expected);
 }
 
@@ -362,10 +362,19 @@ TEST(BoundingBoxExtraction, AngularTieEnclosure) {
 TEST(BoundingBoxExtraction, ThinRectangleFromSuppliedHull) {
   const auto points = angularTiePoints();
   const BoundingBox::PointVectorAdaptor adaptor(points);
-  for (const auto& hull : {std::list<size_t>{3, 2, 0}, std::list<size_t>{0, 2, 3}}) {
+  const auto expected_area = 0.00034844631772374903;
+  {  // check ordering
+    std::vector<size_t> hull{3, 2, 0};
     const auto result = bounding_box::getMin2DBox(adaptor, hull);
     ASSERT_TRUE(result.min_area);
-    EXPECT_NEAR(*result.min_area, 0.00034844631772374903, 1.0e-10);
+    EXPECT_NEAR(*result.min_area, expected_area, 1.0e-10);
+  }
+
+  {  // check ordering
+    std::vector<size_t> hull{0, 2, 3};
+    const auto result = bounding_box::getMin2DBox(adaptor, hull);
+    ASSERT_TRUE(result.min_area);
+    EXPECT_NEAR(*result.min_area, expected_area, 1.0e-10);
   }
 }
 

--- a/tests/utest_mesh.cpp
+++ b/tests/utest_mesh.cpp
@@ -34,6 +34,7 @@
  * -------------------------------------------------------------------------- */
 #include <gtest/gtest.h>
 
+#include <numbers>
 #include <unordered_set>
 
 #include "spark_dsg/mesh.h"
@@ -113,7 +114,7 @@ TEST(MeshTests, transform) {
 
   // Rotation.
   transform = Eigen::Isometry3f::Identity();
-  transform.rotate(Eigen::AngleAxisf(M_PI_2, Eigen::Vector3f::UnitZ()));
+  transform.rotate(Eigen::AngleAxisf(std::numbers::pi / 2.0, Eigen::Vector3f::UnitZ()));
   mesh.transform(transform);
   for (size_t i = 0; i < mesh.numVertices(); ++i) {
     EXPECT_NEAR(

--- a/tests/utest_ray_traversability_boundary.cpp
+++ b/tests/utest_ray_traversability_boundary.cpp
@@ -36,6 +36,8 @@
 #include <spark_dsg/node_attributes.h>
 #include <spark_dsg/traversability_boundary.h>
 
+#include <numbers>
+
 using State = spark_dsg::TraversabilityState;
 using States = spark_dsg::TraversabilityStates;
 using Vec = Eigen::Vector3d;
@@ -94,7 +96,7 @@ TEST(RayBoundary, Area) {
   EXPECT_NEAR(boundary.area(), 2 * std::sqrt(2.0), 1e-6);
 
   boundary.radii.resize(10000, 1.0);
-  EXPECT_NEAR(boundary.area(), M_PI, 1e-6);
+  EXPECT_NEAR(boundary.area(), std::numbers::pi, 1e-6);
 }
 
 TEST(RayBoundary, Contains) {


### PR DESCRIPTION
Fixes numerical precision issues with convex hull computation by switching to the monotone chain algorithm instead of the Graham scan algorithm and adds unit tests

Developed with Codex (GPT-6).